### PR TITLE
Move service worker code out of `src/side-panel/`

### DIFF
--- a/src/service-worker/action-icon.ts
+++ b/src/service-worker/action-icon.ts
@@ -3,6 +3,25 @@
  * @license BSD-3-Clause
  */
 
+// react
+import { lightGreen } from "@mui/material/colors";
+
+const BadgeColor = {
+  REC_TEXT: "#000000FF", // Black
+  REC_BACKGROUND: lightGreen["A400"],
+} as const;
+
+type BadgeColor = (typeof BadgeColor)[keyof typeof BadgeColor];
+
+const IconPath = {
+  ACTIVE: "../image/id-card-active-128x128.png",
+  DEFAULT: "../image/id-card-default-128x128.png",
+} as const;
+
+type IconPath = (typeof IconPath)[keyof typeof IconPath];
+
+export { BadgeColor, IconPath };
+
 const hideBadge = () => {
   chrome.action.setBadgeText({ text: "" }, () => {});
 };

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -27,7 +27,7 @@ import { dumpSessionArchive, loadSessionArchive } from "@/common/services/sessio
 import { BadgeColor, hideBadge, showBadge } from "@/service-worker/action-icon.ts";
 import { setupMonitoring, startMonitoring, stopMonitoring } from "@/service-worker/http-monitor.ts";
 import { processHttpMessage } from "@/service-worker/saml-recorder.ts";
-import "@/service-worker/sidepanel-activator.ts";
+import { setupSidePanel } from "@/service-worker/side-panel.ts";
 
 function init() {
   registerStartMonitoringHandler(onStartMonitoring);
@@ -69,6 +69,8 @@ function init() {
       }
     },
   );
+
+  setupSidePanel();
 }
 
 async function onStartMonitoring(tabId: number): Promise<void | Error> {

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -24,6 +24,7 @@ import {
 } from "@/common/rpc.ts";
 import { deleteSession, getSessionSummaries } from "@/common/services/session-manager.ts";
 import { dumpSessionArchive, loadSessionArchive } from "@/common/services/session-archiver.ts";
+import { BadgeColor, hideBadge, showBadge } from "@/service-worker/action-icon.ts";
 import { setupMonitoring, startMonitoring, stopMonitoring } from "@/service-worker/http-monitor.ts";
 import { processHttpMessage } from "@/service-worker/saml-recorder.ts";
 import "@/service-worker/sidepanel-activator.ts";
@@ -60,6 +61,8 @@ function init() {
       }
     },
     async (tabId, reason) => {
+      hideBadge();
+
       const result = await publishCaptureTerminatedEvent(tabId, reason);
       if (result instanceof Error) {
         console.warn("Failed to publish monitoring terminated event:", result);
@@ -69,11 +72,21 @@ function init() {
 }
 
 async function onStartMonitoring(tabId: number): Promise<void | Error> {
-  return await startMonitoring(tabId);
+  const result = await startMonitoring(tabId);
+  if (result instanceof Error) {
+    return result;
+  }
+
+  showBadge("REC", BadgeColor.REC_TEXT, BadgeColor.REC_BACKGROUND);
 }
 
 async function onStopMonitoring(tabId: number): Promise<void | Error> {
-  return await stopMonitoring(tabId);
+  const result = await stopMonitoring(tabId);
+  if (result instanceof Error) {
+    return result;
+  }
+
+  hideBadge();
 }
 
 async function onGetSessionSummaries(tabId: number): Promise<SessionSummary[] | Error> {

--- a/src/service-worker/side-panel.ts
+++ b/src/service-worker/side-panel.ts
@@ -85,7 +85,7 @@ const registerCloseHandler = () => {
   });
 };
 
-export function activate() {
+export function setupSidePanel() {
   registerOpenHandler();
   registerCloseHandler();
 }

--- a/src/service-worker/sidepanel-activator.ts
+++ b/src/service-worker/sidepanel-activator.ts
@@ -1,8 +1,0 @@
-/**
- * @copyright Internet Initiative Japan Inc. All rights reserved.
- * @license BSD-3-Clause
- */
-
-import * as SidePanel from "@/side-panel/extensions/service-worker.ts";
-
-SidePanel.activate();

--- a/src/side-panel/config.ts
+++ b/src/side-panel/config.ts
@@ -3,23 +3,6 @@
  * @license BSD-3-Clause
  */
 
-// react
-import { lightGreen } from "@mui/material/colors";
-
-const BadgeColor = {
-  REC_TEXT: "#000000FF", // Black
-  REC_BACKGROUND: lightGreen["A400"],
-} as const;
-
-type BadgeColor = (typeof BadgeColor)[keyof typeof BadgeColor];
-
-const IconPath = {
-  ACTIVE: "../image/id-card-active-128x128.png",
-  DEFAULT: "../image/id-card-default-128x128.png",
-} as const;
-
-type IconPath = (typeof IconPath)[keyof typeof IconPath];
-
 const SidePanelState = {
   STOPPED: "STOPPED",
   RECORDING: "RECORDING",
@@ -28,4 +11,4 @@ const SidePanelState = {
 
 type SidePanelState = (typeof SidePanelState)[keyof typeof SidePanelState];
 
-export { BadgeColor, IconPath, SidePanelState };
+export { SidePanelState };

--- a/src/side-panel/extensions/service-worker.ts
+++ b/src/side-panel/extensions/service-worker.ts
@@ -5,12 +5,10 @@
 
 // @ts-expect-error "Avoid errors caused by erasableSyntaxOnly"
 import ContextType = chrome.runtime.ContextType;
-// side-panel
-import { IconPath } from "@/side-panel/config.ts";
-import { hideBadge } from "@/side-panel/extensions/badge.ts";
 // local
 import { isAttached } from "@/common/utils/chrome-debugger.ts";
 import { getActiveTabId } from "@/common/utils/chrome-tabs.ts";
+import { IconPath, hideBadge } from "@/service-worker/action-icon.ts";
 import { stopMonitoring } from "@/service-worker/http-monitor.ts";
 
 const registerOpenHandler = () => {

--- a/src/side-panel/record-panel/RecordButton.tsx
+++ b/src/side-panel/record-panel/RecordButton.tsx
@@ -8,8 +8,7 @@ import React from "react";
 import { Fab, type FabOwnProps } from "@mui/material";
 import { Start } from "@mui/icons-material";
 // side-panel
-import { BadgeColor, SidePanelState } from "@/side-panel/config.ts";
-import { showBadge } from "@/side-panel/extensions/badge.ts";
+import { SidePanelState } from "@/side-panel/config.ts";
 // local
 import type { SessionSummary } from "@/common/models/session-summary.ts";
 import { startMonitoring } from "@/common/rpc.ts";
@@ -40,7 +39,6 @@ const RecordButton = ({
     }
     // Managing state
     setPanelState(SidePanelState.RECORDING);
-    showBadge("REC", BadgeColor.REC_TEXT, BadgeColor.REC_BACKGROUND);
   };
 
   return (

--- a/src/side-panel/record-panel/RecordPanel.tsx
+++ b/src/side-panel/record-panel/RecordPanel.tsx
@@ -13,7 +13,6 @@ import { RecordButton } from "@/side-panel/record-panel/RecordButton.tsx";
 import { StopButton } from "@/side-panel/record-panel/StopButton.tsx";
 import { SidePanelState } from "@/side-panel/config.ts";
 import { useEffectOnce } from "@/side-panel/utils.ts";
-import { hideBadge } from "@/side-panel/extensions/badge.ts";
 // local
 import type { SessionSummary } from "@/common/models/session-summary.ts";
 import { type CaptureTerminatedReason, subscribeCaptureTerminatedEvent } from "@/common/pubsub.ts";
@@ -44,7 +43,6 @@ const RecordPanel = ({
         console.info(`[${tabId}]: CaptureTerminatedEvent occurred:`, reason);
         // Managing state
         setPanelState(SidePanelState.STOPPED);
-        hideBadge();
         // Update SessionCardList
         if (tabId !== subscribeTabId) {
           console.warn(`[${tabId}]: tabId mismatched: subscribeTabId = ${subscribeTabId}`);

--- a/src/side-panel/record-panel/StopButton.tsx
+++ b/src/side-panel/record-panel/StopButton.tsx
@@ -9,7 +9,6 @@ import { Fab, type FabOwnProps } from "@mui/material";
 import { Stop } from "@mui/icons-material";
 // side-panel
 import { SidePanelState } from "@/side-panel/config.ts";
-import { hideBadge } from "@/side-panel/extensions/badge.ts";
 // local
 import type { SessionSummary } from "@/common/models/session-summary.ts";
 import { stopMonitoring } from "@/common/rpc.ts";
@@ -41,7 +40,6 @@ const StopButton = ({
     }
     // Managing state
     setPanelState(SidePanelState.STOPPED);
-    hideBadge();
     // Update SessionCardList
     if (setSessionSummaries !== undefined) {
       const result = await getSessionSummaries(tabId);


### PR DESCRIPTION
Service worker code was under `src/side-panel/extensions/`, with imports across the boundary in both directions.
This moves that code to `src/service-worker/` and removes the cross imports.

- `side-panel/extensions/badge.ts` moved to `service-worker/action-icon.ts`, along with the action icon definitions in `side-panel/config.ts`.
- Badge control moved from the `side-panel/record-panel/` components to `service-worker/index.ts`, which already handles the start, stop, and termination of monitoring. The side panel no longer calls `chrome.action`.
- `side-panel/extensions/service-worker.ts` moved to `service-worker/side-panel.ts`.

No user-visible behavior change.
