### PR TITLE
Clean up service worker event handlers

### DIFF
--- a/src/service-worker/debugger-controller.ts
+++ b/src/service-worker/debugger-controller.ts
@@ -21,9 +21,8 @@ export function registerDebuggerDetachHandler(
   // Event fired when debugger is detached by Chrome.
   // Not fired when chrome.debugger.detach() is called.
   chrome.debugger.onDetach.addListener((source, reason) => {
-    console.info("Debugger detached:", { source, reason });
-
     if (source.tabId === undefined) {
+      console.warn("Unexpected debuggee without tab ID:", { source, reason });
       // Nothing we can do without the tab ID
       return;
     }

--- a/src/service-worker/http-interception.test.ts
+++ b/src/service-worker/http-interception.test.ts
@@ -5,7 +5,7 @@
 
 import type Protocol from "devtools-protocol";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { setupInterception } from "./http-interception.ts";
+import { registerHttpInterceptionHandlers } from "./http-interception.ts";
 
 //
 // Helpers
@@ -63,10 +63,10 @@ function makeResponsePausedEvent(responseStatusCode: number): Protocol.Fetch.Req
 // Tests
 //
 
-describe("setupInterception", () => {
+describe("registerHttpInterceptionHandlers", () => {
   it("does not send Fetch.getResponseBody for redirects", async () => {
     const onInterceptHttpResponse = vi.fn();
-    setupInterception(vi.fn(), onInterceptHttpResponse);
+    registerHttpInterceptionHandlers(vi.fn(), onInterceptHttpResponse);
 
     fireDebuggerEvent({ tabId: 1 }, "Fetch.requestPaused", makeResponsePausedEvent(302));
 
@@ -89,7 +89,7 @@ describe("setupInterception", () => {
       }
     });
     const onInterceptHttpResponse = vi.fn();
-    setupInterception(vi.fn(), onInterceptHttpResponse);
+    registerHttpInterceptionHandlers(vi.fn(), onInterceptHttpResponse);
 
     fireDebuggerEvent({ tabId: 1 }, "Fetch.requestPaused", makeResponsePausedEvent(200));
 

--- a/src/service-worker/http-interception.ts
+++ b/src/service-worker/http-interception.ts
@@ -12,7 +12,7 @@ import {
 } from "@/common/models/http-message.ts";
 import { isObject } from "@/common/utils/type-guard.ts";
 
-export function setupInterception(
+export function registerHttpInterceptionHandlers(
   onInterceptHttpRequest: (tabId: number, httpRequest: HttpRequest) => Promise<void>,
   onInterceptHttpResponse: (tabId: number, httpResponse: HttpResponse) => Promise<void>,
 ): void {

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -31,7 +31,7 @@ import {
   startCapturing,
   stopCapturing,
 } from "@/service-worker/capture-manager.ts";
-import { setupInterception } from "@/service-worker/http-interception.ts";
+import { registerHttpInterceptionHandlers } from "@/service-worker/http-interception.ts";
 import { processHttpMessage } from "@/service-worker/saml-recorder.ts";
 import {
   registerSidePanelCloseHandler,
@@ -46,7 +46,7 @@ function init() {
   registerDumpSessionHandler(onDumpSession);
   registerLoadSessionHandler(onLoadSession);
 
-  setupInterception(
+  registerHttpInterceptionHandlers(
     async (tabId, httpRequest) => {
       const sessionId = await processHttpMessage(tabId, httpRequest);
       if (sessionId instanceof Error) {


### PR DESCRIPTION
- **Rename setupInterception for naming consistency**
- **Warn only when detached debuggee has no tab ID**
