### PR TITLE
Link SAML traces to SSO flows

### DIFF
--- a/src/common/models/saml-detection.ts
+++ b/src/common/models/saml-detection.ts
@@ -3,7 +3,15 @@
  * @license BSD-3-Clause
  */
 
-export type SamlDetection = SamlDetectionFromHttpRequest | SamlDetectionFromHttpResponse;
+export type SamlDetection =
+  | InferredSamlDetection
+  | SamlDetectionFromHttpRequest
+  | SamlDetectionFromHttpResponse;
+
+export type InferredSamlDetection = {
+  step: 1;
+  correlationKey: string;
+};
 
 export type SamlDetectionFromHttpRequest =
   | {

--- a/src/common/models/saml-trace.test.ts
+++ b/src/common/models/saml-trace.test.ts
@@ -145,6 +145,25 @@ describe("newSamlTrace", () => {
     } as unknown as HttpResponse;
   }
 
+  it("builds a step 1 trace from a request", () => {
+    const request = makeRequest({ url: "https://sp.example.com/resource" });
+
+    const result = newSamlTrace("flow-1", { step: 1, correlationKey: "authn-req-1" }, request);
+
+    expect(result).not.toBeInstanceOf(Error);
+    expect(result).toMatchObject({
+      flowId: "flow-1",
+      httpMessageId: "msg-1",
+      observedAt: "2026-01-01T00:00:00Z",
+      serverHostname: "sp.example.com",
+      sessionId: "authn-req-1",
+      imported: false,
+      step: 1,
+      type: "UnauthenticatedResourceRequest",
+      action: "User Agent requests a secured resource at Service Provider",
+    });
+  });
+
   it("builds a step 2 trace from a response", () => {
     const response = makeResponse({ url: "https://sp.example.com/login" });
 

--- a/src/common/models/saml-trace.test.ts
+++ b/src/common/models/saml-trace.test.ts
@@ -8,8 +8,13 @@ import { type HttpRequest, type HttpResponse } from "@/common/models/http-messag
 import { isSamlTrace, newSamlTrace } from "./saml-trace.ts";
 
 describe("isSamlTrace", () => {
-  it("returns true for valid SamlTrace with required fields only", () => {
-    const msg = {
+  function makeTraceFields(): Record<string, unknown> {
+    return {
+      id: "trace-1",
+      flowId: "flow-1",
+      httpMessageId: "msg-1",
+      observedAt: "2026-01-01T00:00:00Z",
+      serverHostname: "sp.example.com",
       sessionId: "abc123",
       createdAt: "2026-01-01T00:00:00Z",
       imported: false,
@@ -17,17 +22,15 @@ describe("isSamlTrace", () => {
       step: 2,
       type: "IncomingAuthnRequest",
     };
-    expect(isSamlTrace(msg)).toBe(true);
+  }
+
+  it("returns true for valid SamlTrace with required fields only", () => {
+    expect(isSamlTrace(makeTraceFields())).toBe(true);
   });
 
   it("returns true for valid SamlTrace with optional fields", () => {
     const msg = {
-      sessionId: "abc123",
-      createdAt: "2026-01-01T00:00:00Z",
-      imported: true,
-      action: "test action",
-      step: 3,
-      type: "OutgoingAuthnRequest",
+      ...makeTraceFields(),
       date: "2026-01-01",
       sp: "sp.example.com",
       idp: "idp.example.org",
@@ -43,86 +46,66 @@ describe("isSamlTrace", () => {
     expect(isSamlTrace(undefined)).toBe(false);
   });
 
+  it("returns false when id is missing", () => {
+    const msg = makeTraceFields();
+    delete msg.id;
+    expect(isSamlTrace(msg)).toBe(false);
+  });
+
+  it("returns false when flowId is missing", () => {
+    const msg = makeTraceFields();
+    delete msg.flowId;
+    expect(isSamlTrace(msg)).toBe(false);
+  });
+
+  it("returns false when httpMessageId is not a string", () => {
+    expect(isSamlTrace({ ...makeTraceFields(), httpMessageId: 123 })).toBe(false);
+  });
+
+  it("returns false when observedAt is missing", () => {
+    const msg = makeTraceFields();
+    delete msg.observedAt;
+    expect(isSamlTrace(msg)).toBe(false);
+  });
+
+  it("returns false when serverHostname is not a string", () => {
+    expect(isSamlTrace({ ...makeTraceFields(), serverHostname: null })).toBe(false);
+  });
+
   it("returns false when sessionId is missing", () => {
-    const msg = {
-      createdAt: "2026-01-01T00:00:00Z",
-      imported: false,
-      action: "test action",
-    };
+    const msg = makeTraceFields();
+    delete msg.sessionId;
     expect(isSamlTrace(msg)).toBe(false);
   });
 
   it("returns false when sessionId is not a string", () => {
-    const msg = {
-      sessionId: 123,
-      createdAt: "2026-01-01T00:00:00Z",
-      imported: false,
-      action: "test action",
-    };
-    expect(isSamlTrace(msg)).toBe(false);
+    expect(isSamlTrace({ ...makeTraceFields(), sessionId: 123 })).toBe(false);
   });
 
   it("returns false when createdAt is missing", () => {
-    const msg = {
-      sessionId: "abc123",
-      imported: false,
-      action: "test action",
-    };
+    const msg = makeTraceFields();
+    delete msg.createdAt;
     expect(isSamlTrace(msg)).toBe(false);
   });
 
   it("returns false when imported is not a boolean", () => {
-    const msg = {
-      sessionId: "abc123",
-      createdAt: "2026-01-01T00:00:00Z",
-      imported: "false",
-      action: "test action",
-    };
-    expect(isSamlTrace(msg)).toBe(false);
+    expect(isSamlTrace({ ...makeTraceFields(), imported: "false" })).toBe(false);
   });
 
   it("returns false when optional date is not a string", () => {
-    const msg = {
-      sessionId: "abc123",
-      createdAt: "2026-01-01T00:00:00Z",
-      imported: false,
-      action: "test action",
-      date: 12345,
-    };
-    expect(isSamlTrace(msg)).toBe(false);
+    expect(isSamlTrace({ ...makeTraceFields(), date: 12345 })).toBe(false);
   });
 
   it("returns false when optional sp is not a string", () => {
-    const msg = {
-      sessionId: "abc123",
-      createdAt: "2026-01-01T00:00:00Z",
-      imported: false,
-      action: "test action",
-      sp: null,
-    };
-    expect(isSamlTrace(msg)).toBe(false);
+    expect(isSamlTrace({ ...makeTraceFields(), sp: null })).toBe(false);
   });
 
   it("returns false when optional idp is not a string", () => {
-    const msg = {
-      sessionId: "abc123",
-      createdAt: "2026-01-01T00:00:00Z",
-      imported: false,
-      action: "test action",
-      idp: { name: "idp" },
-    };
-    expect(isSamlTrace(msg)).toBe(false);
+    expect(isSamlTrace({ ...makeTraceFields(), idp: { name: "idp" } })).toBe(false);
   });
 
   it("returns false when optional samlStatusCode is not a string", () => {
-    const msg = {
-      sessionId: "abc123",
-      createdAt: "2026-01-01T00:00:00Z",
-      imported: false,
-      action: "test action",
-      samlStatusCode: 200,
-    };
-    expect(isSamlTrace(msg)).toBe(false);
+    expect(isSamlTrace({ ...makeTraceFields(), samlStatusCode: 200 })).toBe(false);
   });
 });
 
@@ -133,6 +116,7 @@ describe("newSamlTrace", () => {
 
   function makeRequest(overrides: Record<string, unknown> = {}): HttpRequest {
     return {
+      id: "msg-1",
       createdAt: "2026-01-01T00:00:00Z",
       imported: false,
       stage: "Request",
@@ -147,6 +131,7 @@ describe("newSamlTrace", () => {
 
   function makeResponse(overrides: Record<string, unknown> = {}): HttpResponse {
     return {
+      id: "msg-1",
       createdAt: "2026-01-01T00:00:00Z",
       imported: false,
       stage: "Response",
@@ -163,10 +148,14 @@ describe("newSamlTrace", () => {
   it("builds a step 2 trace from a response", () => {
     const response = makeResponse({ url: "https://sp.example.com/login" });
 
-    const result = newSamlTrace({ step: 2, correlationKey: "authn-req-1" }, response);
+    const result = newSamlTrace("flow-1", { step: 2, correlationKey: "authn-req-1" }, response);
 
     expect(result).not.toBeInstanceOf(Error);
     expect(result).toMatchObject({
+      flowId: "flow-1",
+      httpMessageId: "msg-1",
+      observedAt: "2026-01-01T00:00:00Z",
+      serverHostname: "sp.example.com",
       sessionId: "authn-req-1",
       imported: false,
       step: 2,
@@ -175,18 +164,20 @@ describe("newSamlTrace", () => {
       sp: "sp.example.com",
       action: "Service Provider issues SAML AuthnRequest",
     });
+    expect((result as { id: string }).id).toEqual(expect.any(String));
     expect((result as { createdAt: string }).createdAt).toEqual(expect.any(String));
   });
 
   it("builds a step 3 trace with the redirect action for a GET request", () => {
     const request = makeRequest({ url: "https://idp.example.org/sso", method: "GET" });
 
-    const result = newSamlTrace({ step: 3, correlationKey: "authn-req-1" }, request);
+    const result = newSamlTrace("flow-1", { step: 3, correlationKey: "authn-req-1" }, request);
 
     expect(result).toMatchObject({
       sessionId: "authn-req-1",
       step: 3,
       type: "OutgoingAuthnRequest",
+      serverHostname: "idp.example.org",
       idp: "idp.example.org",
       action: "User Agent redirects SAML AuthnRequest to Identity Provider",
     });
@@ -195,7 +186,7 @@ describe("newSamlTrace", () => {
   it("builds a step 3 trace with the submit action for a POST request", () => {
     const request = makeRequest({ url: "https://idp.example.org/sso", method: "POST" });
 
-    const result = newSamlTrace({ step: 3, correlationKey: "authn-req-1" }, request);
+    const result = newSamlTrace("flow-1", { step: 3, correlationKey: "authn-req-1" }, request);
 
     expect(result).toMatchObject({
       step: 3,
@@ -207,6 +198,7 @@ describe("newSamlTrace", () => {
     const response = makeResponse({ url: "https://idp.example.org/sso" });
 
     const result = newSamlTrace(
+      "flow-1",
       { step: 4, correlationKey: "authn-req-1", samlStatusCode: STATUS_SUCCESS },
       response,
     );
@@ -226,6 +218,7 @@ describe("newSamlTrace", () => {
     const request = makeRequest({ url: "https://sp.example.com/acs", method: "POST" });
 
     const result = newSamlTrace(
+      "flow-1",
       { step: 5, correlationKey: "authn-req-1", samlStatusCode: STATUS_SUCCESS },
       request,
     );
@@ -243,7 +236,7 @@ describe("newSamlTrace", () => {
   it("builds a step 6 trace from a response", () => {
     const response = makeResponse({ url: "https://sp.example.com/resource" });
 
-    const result = newSamlTrace({ step: 6, correlationKey: "authn-req-1" }, response);
+    const result = newSamlTrace("flow-1", { step: 6, correlationKey: "authn-req-1" }, response);
 
     expect(result).toMatchObject({
       sessionId: "authn-req-1",
@@ -258,7 +251,7 @@ describe("newSamlTrace", () => {
   it("takes the imported flag from the HTTP message", () => {
     const response = makeResponse({ imported: true });
 
-    const result = newSamlTrace({ step: 2, correlationKey: "authn-req-1" }, response);
+    const result = newSamlTrace("flow-1", { step: 2, correlationKey: "authn-req-1" }, response);
 
     expect(result).toMatchObject({ imported: true });
   });
@@ -266,7 +259,7 @@ describe("newSamlTrace", () => {
   it("omits the date when the message has no Date header", () => {
     const response = makeResponse({ headers: [] });
 
-    const result = newSamlTrace({ step: 2, correlationKey: "authn-req-1" }, response);
+    const result = newSamlTrace("flow-1", { step: 2, correlationKey: "authn-req-1" }, response);
 
     expect(result).not.toBeInstanceOf(Error);
     expect((result as { date?: string }).date).toBeUndefined();
@@ -275,7 +268,7 @@ describe("newSamlTrace", () => {
   it("returns Error when the message URL is invalid", () => {
     const response = makeResponse({ url: "not-a-url" });
 
-    const result = newSamlTrace({ step: 2, correlationKey: "authn-req-1" }, response);
+    const result = newSamlTrace("flow-1", { step: 2, correlationKey: "authn-req-1" }, response);
 
     expect(result).toBeInstanceOf(Error);
   });

--- a/src/common/models/saml-trace.test.ts
+++ b/src/common/models/saml-trace.test.ts
@@ -16,7 +16,6 @@ describe("isSamlTrace", () => {
       observedAt: "2026-01-01T00:00:00Z",
       serverHostname: "sp.example.com",
       sessionId: "abc123",
-      createdAt: "2026-01-01T00:00:00Z",
       imported: false,
       action: "test action",
       step: 2,
@@ -29,12 +28,7 @@ describe("isSamlTrace", () => {
   });
 
   it("returns true for valid SamlTrace with optional fields", () => {
-    const msg = {
-      ...makeTraceFields(),
-      date: "2026-01-01",
-      sp: "sp.example.com",
-      idp: "idp.example.org",
-    };
+    const msg = { ...makeTraceFields(), samlStatusCode: "urn:...:Success" };
     expect(isSamlTrace(msg)).toBe(true);
   });
 
@@ -82,26 +76,8 @@ describe("isSamlTrace", () => {
     expect(isSamlTrace({ ...makeTraceFields(), sessionId: 123 })).toBe(false);
   });
 
-  it("returns false when createdAt is missing", () => {
-    const msg = makeTraceFields();
-    delete msg.createdAt;
-    expect(isSamlTrace(msg)).toBe(false);
-  });
-
   it("returns false when imported is not a boolean", () => {
     expect(isSamlTrace({ ...makeTraceFields(), imported: "false" })).toBe(false);
-  });
-
-  it("returns false when optional date is not a string", () => {
-    expect(isSamlTrace({ ...makeTraceFields(), date: 12345 })).toBe(false);
-  });
-
-  it("returns false when optional sp is not a string", () => {
-    expect(isSamlTrace({ ...makeTraceFields(), sp: null })).toBe(false);
-  });
-
-  it("returns false when optional idp is not a string", () => {
-    expect(isSamlTrace({ ...makeTraceFields(), idp: { name: "idp" } })).toBe(false);
   });
 
   it("returns false when optional samlStatusCode is not a string", () => {
@@ -111,7 +87,6 @@ describe("isSamlTrace", () => {
 
 describe("newSamlTrace", () => {
   const DATE_HEADER_VALUE = "Thu, 01 Jan 2026 00:00:00 GMT";
-  const DATE_ISO = "2026-01-01T00:00:00.000Z";
   const STATUS_SUCCESS = "urn:oasis:names:tc:SAML:2.0:status:Success";
 
   function makeRequest(overrides: Record<string, unknown> = {}): HttpRequest {
@@ -179,12 +154,9 @@ describe("newSamlTrace", () => {
       imported: false,
       step: 2,
       type: "IncomingAuthnRequest",
-      date: DATE_ISO,
-      sp: "sp.example.com",
       action: "Service Provider issues SAML AuthnRequest",
     });
     expect((result as { id: string }).id).toEqual(expect.any(String));
-    expect((result as { createdAt: string }).createdAt).toEqual(expect.any(String));
   });
 
   it("builds a step 3 trace with the redirect action for a GET request", () => {
@@ -197,7 +169,6 @@ describe("newSamlTrace", () => {
       step: 3,
       type: "OutgoingAuthnRequest",
       serverHostname: "idp.example.org",
-      idp: "idp.example.org",
       action: "User Agent redirects SAML AuthnRequest to Identity Provider",
     });
   });
@@ -226,8 +197,6 @@ describe("newSamlTrace", () => {
       sessionId: "authn-req-1",
       step: 4,
       type: "IncomingResponse",
-      date: DATE_ISO,
-      idp: "idp.example.org",
       action: "Identity Provider issues SAML Response",
       samlStatusCode: STATUS_SUCCESS,
     });
@@ -246,7 +215,6 @@ describe("newSamlTrace", () => {
       sessionId: "authn-req-1",
       step: 5,
       type: "OutgoingResponse",
-      sp: "sp.example.com",
       action: "User Agent submits SAML Response to Service Provider",
       samlStatusCode: STATUS_SUCCESS,
     });
@@ -261,8 +229,6 @@ describe("newSamlTrace", () => {
       sessionId: "authn-req-1",
       step: 6,
       type: "AuthenticatedResourceResponse",
-      date: DATE_ISO,
-      sp: "sp.example.com",
       action: "Service Provider returns the requested resource",
     });
   });
@@ -273,15 +239,6 @@ describe("newSamlTrace", () => {
     const result = newSamlTrace("flow-1", { step: 2, correlationKey: "authn-req-1" }, response);
 
     expect(result).toMatchObject({ imported: true });
-  });
-
-  it("omits the date when the message has no Date header", () => {
-    const response = makeResponse({ headers: [] });
-
-    const result = newSamlTrace("flow-1", { step: 2, correlationKey: "authn-req-1" }, response);
-
-    expect(result).not.toBeInstanceOf(Error);
-    expect((result as { date?: string }).date).toBeUndefined();
   });
 
   it("returns Error when the message URL is invalid", () => {

--- a/src/common/models/saml-trace.ts
+++ b/src/common/models/saml-trace.ts
@@ -4,7 +4,7 @@
  */
 
 import { v7 as uuidv7 } from "uuid";
-import { type HttpMessage, getHeaderValue } from "@/common/models/http-message.ts";
+import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlDetection } from "@/common/models/saml-detection.ts";
 import { createLabeledDebugLogger } from "@/common/utils/labeled-logger.ts";
 import { isObject } from "@/common/utils/type-guard.ts";
@@ -24,11 +24,7 @@ type SamlTraceBase = {
   observedAt: string;
   serverHostname: string;
   sessionId: string;
-  createdAt: string;
   imported: boolean;
-  date?: string;
-  sp?: string;
-  idp?: string;
   action: string;
 };
 
@@ -79,11 +75,7 @@ export function isSamlTrace(u: unknown): u is SamlTrace {
     typeof u.observedAt === "string" &&
     typeof u.serverHostname === "string" &&
     typeof u.sessionId === "string" &&
-    typeof u.createdAt === "string" &&
     typeof u.imported === "boolean" &&
-    (!("date" in u) || typeof u.date === "string") &&
-    (!("sp" in u) || typeof u.sp === "string") &&
-    (!("idp" in u) || typeof u.idp === "string") &&
     (!("samlStatusCode" in u) || typeof u.samlStatusCode === "string")
   );
 }
@@ -105,7 +97,6 @@ export function newSamlTrace(
     observedAt: httpMessage.createdAt,
     serverHostname: hostname,
     sessionId: detection.correlationKey,
-    createdAt: new Date().toISOString(),
     imported: httpMessage.imported,
   };
 
@@ -115,7 +106,6 @@ export function newSamlTrace(
         ...base,
         step: 1,
         type: "UnauthenticatedResourceRequest",
-        sp: hostname,
         action: "User Agent requests a secured resource at Service Provider",
       };
     case 2:
@@ -123,8 +113,6 @@ export function newSamlTrace(
         ...base,
         step: 2,
         type: "IncomingAuthnRequest",
-        date: getResponseDate(httpMessage),
-        sp: hostname,
         action: "Service Provider issues SAML AuthnRequest",
       };
     case 3:
@@ -132,7 +120,6 @@ export function newSamlTrace(
         ...base,
         step: 3,
         type: "OutgoingAuthnRequest",
-        idp: hostname,
         action:
           httpMessage.method === "POST"
             ? "User Agent submits SAML AuthnRequest to Identity Provider"
@@ -143,8 +130,6 @@ export function newSamlTrace(
         ...base,
         step: 4,
         type: "IncomingResponse",
-        date: getResponseDate(httpMessage),
-        idp: hostname,
         action: "Identity Provider issues SAML Response",
         samlStatusCode: detection.samlStatusCode,
       };
@@ -153,7 +138,6 @@ export function newSamlTrace(
         ...base,
         step: 5,
         type: "OutgoingResponse",
-        sp: hostname,
         action:
           httpMessage.method === "POST"
             ? "User Agent submits SAML Response to Service Provider"
@@ -165,8 +149,6 @@ export function newSamlTrace(
         ...base,
         step: 6,
         type: "AuthenticatedResourceResponse",
-        date: getResponseDate(httpMessage),
-        sp: hostname,
         action: "Service Provider returns the requested resource",
       };
   }
@@ -178,22 +160,6 @@ function getHostname(url: string): string | Error {
   } catch (err) {
     return new Error("Failed to extract hostname from url", { cause: err });
   }
-}
-
-function getResponseDate(httpMessage: HttpMessage): string | undefined {
-  const dateStr = getHeaderValue(httpMessage, "Date");
-  if (!dateStr) {
-    console.info("No Date header:", { headers: httpMessage.headers, url: httpMessage.url });
-    return undefined;
-  }
-
-  const date = new Date(dateStr);
-  if (isNaN(date.getTime())) {
-    console.info("Invalid Date header:", { headers: httpMessage.headers, url: httpMessage.url });
-    return undefined;
-  }
-
-  return date.toISOString();
 }
 
 //

--- a/src/common/models/saml-trace.ts
+++ b/src/common/models/saml-trace.ts
@@ -3,6 +3,7 @@
  * @license BSD-3-Clause
  */
 
+import { v7 as uuidv7 } from "uuid";
 import { type HttpMessage, getHeaderValue } from "@/common/models/http-message.ts";
 import { type SamlDetection } from "@/common/models/saml-detection.ts";
 import { createLabeledDebugLogger } from "@/common/utils/labeled-logger.ts";
@@ -17,6 +18,11 @@ export type SamlTrace =
   | AuthenticatedResourceResponse;
 
 type SamlTraceBase = {
+  id: string;
+  flowId: string;
+  httpMessageId: string;
+  observedAt: string;
+  serverHostname: string;
   sessionId: string;
   createdAt: string;
   imported: boolean;
@@ -67,6 +73,11 @@ export type AuthenticatedResourceResponse = SamlTraceBase & {
 export function isSamlTrace(u: unknown): u is SamlTrace {
   return (
     isObject(u) &&
+    typeof u.id === "string" &&
+    typeof u.flowId === "string" &&
+    typeof u.httpMessageId === "string" &&
+    typeof u.observedAt === "string" &&
+    typeof u.serverHostname === "string" &&
     typeof u.sessionId === "string" &&
     typeof u.createdAt === "string" &&
     typeof u.imported === "boolean" &&
@@ -78,6 +89,7 @@ export function isSamlTrace(u: unknown): u is SamlTrace {
 }
 
 export function newSamlTrace(
+  flowId: string,
   detection: SamlDetection,
   httpMessage: HttpMessage,
 ): SamlTrace | Error {
@@ -87,6 +99,11 @@ export function newSamlTrace(
   }
 
   const base = {
+    id: uuidv7(),
+    flowId,
+    httpMessageId: httpMessage.id,
+    observedAt: httpMessage.createdAt,
+    serverHostname: hostname,
     sessionId: detection.correlationKey,
     createdAt: new Date().toISOString(),
     imported: httpMessage.imported,

--- a/src/common/models/saml-trace.ts
+++ b/src/common/models/saml-trace.ts
@@ -110,6 +110,14 @@ export function newSamlTrace(
   };
 
   switch (detection.step) {
+    case 1:
+      return {
+        ...base,
+        step: 1,
+        type: "UnauthenticatedResourceRequest",
+        sp: hostname,
+        action: "User Agent requests a secured resource at Service Provider",
+      };
     case 2:
       return {
         ...base,

--- a/src/common/services/flow-store.test.ts
+++ b/src/common/services/flow-store.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   findFlowEntriesByCaptureSessionId,
   findFlowEntryByCorrelationKey,
+  findFlowEntryById,
   saveFlowEntry,
 } from "./flow-store.ts";
 
@@ -161,5 +162,20 @@ describe("findFlowEntryByCorrelationKey", () => {
     vi.mocked(getAllSessionStorageKeys).mockResolvedValue(error);
 
     expect(await findFlowEntryByCorrelationKey("cs-1", "key-1")).toBe(error);
+  });
+});
+
+describe("findFlowEntryById", () => {
+  it("retrieves the flow with the ID", async () => {
+    const target = newFlowEntry("cs-1", "saml", "key-1");
+    mockStorage(newFlowEntry("cs-1", "saml", "key-2"), target);
+
+    expect(await findFlowEntryById(target.id)).toEqual(target);
+  });
+
+  it("returns undefined when no flow has the ID", async () => {
+    mockStorage(newFlowEntry("cs-1", "saml", "key-1"));
+
+    expect(await findFlowEntryById("unknown-id")).toBeUndefined();
   });
 });

--- a/src/common/services/flow-store.ts
+++ b/src/common/services/flow-store.ts
@@ -26,6 +26,15 @@ export async function findFlowEntriesByCaptureSessionId(
   return entries.toReversed();
 }
 
+export async function findFlowEntryById(id: string): Promise<FlowEntry | undefined | Error> {
+  const entries = await findFlowEntriesBy((e) => e.id === id);
+  if (entries instanceof Error) {
+    return entries;
+  }
+
+  return entries[0];
+}
+
 export async function findFlowEntryByCorrelationKey(
   captureSessionId: string,
   correlationKey: string,

--- a/src/common/services/saml-recorder.test.ts
+++ b/src/common/services/saml-recorder.test.ts
@@ -5,8 +5,8 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type FlowEntry, isFlowEntry } from "@/common/models/flow-entry.ts";
-import { type HttpResponse } from "@/common/models/http-message.ts";
-import { isSamlTrace } from "@/common/models/saml-trace.ts";
+import { type HttpRequest, type HttpResponse } from "@/common/models/http-message.ts";
+import { type SamlTrace, isSamlTrace } from "@/common/models/saml-trace.ts";
 import {
   getAllSessionStorageKeys,
   getSessionStorageItems,
@@ -37,6 +37,26 @@ beforeEach(() => {
 
 function storedFlowEntries(): FlowEntry[] {
   return Object.values(storage).filter((v): v is FlowEntry => isFlowEntry(v));
+}
+
+function storedSamlTraces(): SamlTrace[] {
+  return Object.values(storage)
+    .filter((v): v is SamlTrace => isSamlTrace(v))
+    .toSorted((a, b) => (a.id < b.id ? -1 : 1));
+}
+
+function makeRequest(): HttpRequest {
+  return {
+    id: "msg-0",
+    createdAt: "2025-12-31T23:59:59Z",
+    imported: false,
+    stage: "Request",
+    fetchRequestId: "req-1",
+    headers: [],
+    url: "https://sp.example.com/resource",
+    method: "GET",
+    body: "",
+  } as unknown as HttpRequest;
 }
 
 function makeResponse(): HttpResponse {
@@ -71,21 +91,83 @@ describe("recordSamlTrace", () => {
         correlationKey: "authn-req-1",
       }),
     ]);
-    const samlTraces = Object.values(storage).filter((v) => isSamlTrace(v));
+    const samlTraces = storedSamlTraces();
     expect(samlTraces).toHaveLength(1);
     expect(samlTraces[0]).toMatchObject({ flowId: storedFlowEntries()[0]!.id });
   });
 
-  it("reuses the flow of the same correlation key", async () => {
+  it("stores the step 1 trace before the step 2 trace", async () => {
+    const pairedHttpRequest = makeRequest();
+
+    const result = await recordSamlTrace(
+      "cs-1",
+      1,
+      { step: 2, correlationKey: "authn-req-1" },
+      makeResponse(),
+      pairedHttpRequest,
+    );
+
+    expect(result).toBeUndefined();
+    const samlTraces = storedSamlTraces();
+    expect(samlTraces.map((t) => t.step)).toEqual([1, 2]);
+    expect(samlTraces[0]).toMatchObject({
+      flowId: storedFlowEntries()[0]!.id,
+      httpMessageId: pairedHttpRequest.id,
+      observedAt: pairedHttpRequest.createdAt,
+      serverHostname: "sp.example.com",
+      sessionId: "authn-req-1",
+      action: "User Agent requests a secured resource at Service Provider",
+    });
+  });
+
+  it("skips the step 1 trace when the paired request is missing", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
     await recordSamlTrace("cs-1", 1, { step: 2, correlationKey: "authn-req-1" }, makeResponse());
+
+    expect(storedSamlTraces().map((t) => t.step)).toEqual([2]);
+    expect(consoleWarn).toHaveBeenCalledOnce();
+  });
+
+  it("does not issue a step 1 trace for steps other than 2", async () => {
+    await recordSamlTrace(
+      "cs-1",
+      1,
+      { step: 6, correlationKey: "authn-req-1" },
+      makeResponse(),
+      makeRequest(),
+    );
+
+    expect(storedSamlTraces().map((t) => t.step)).toEqual([6]);
+  });
+
+  it("returns an error when the step 1 trace cannot be built", async () => {
+    const pairedHttpRequest = { ...makeRequest(), url: "not a url" } as HttpRequest;
+
+    const result = await recordSamlTrace(
+      "cs-1",
+      1,
+      { step: 2, correlationKey: "authn-req-1" },
+      makeResponse(),
+      pairedHttpRequest,
+    );
+
+    expect(result).toBeInstanceOf(Error);
+    expect(storedSamlTraces()).toEqual([]);
+  });
+
+  it("reuses the flow of the same correlation key", async () => {
+    const detection = { step: 2, correlationKey: "authn-req-1" } as const;
+    await recordSamlTrace("cs-1", 1, detection, makeResponse(), makeRequest());
     await recordSamlTrace("cs-1", 1, { step: 6, correlationKey: "authn-req-1" }, makeResponse());
 
     expect(storedFlowEntries()).toHaveLength(1);
   });
 
   it("issues a flow per capture session", async () => {
-    await recordSamlTrace("cs-1", 1, { step: 2, correlationKey: "authn-req-1" }, makeResponse());
-    await recordSamlTrace("cs-2", 1, { step: 2, correlationKey: "authn-req-1" }, makeResponse());
+    const detection = { step: 2, correlationKey: "authn-req-1" } as const;
+    await recordSamlTrace("cs-1", 1, detection, makeResponse(), makeRequest());
+    await recordSamlTrace("cs-2", 1, detection, makeResponse(), makeRequest());
 
     expect(storedFlowEntries().map((f) => f.captureSessionId)).toEqual(["cs-1", "cs-2"]);
   });
@@ -98,6 +180,7 @@ describe("recordSamlTrace", () => {
       1,
       { step: 2, correlationKey: "authn-req-1" },
       httpResponse,
+      makeRequest(),
     );
 
     expect(result).toBeInstanceOf(Error);

--- a/src/common/services/saml-recorder.test.ts
+++ b/src/common/services/saml-recorder.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @copyright Internet Initiative Japan Inc. All rights reserved.
+ * @license BSD-3-Clause
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type FlowEntry, isFlowEntry } from "@/common/models/flow-entry.ts";
+import { type HttpResponse } from "@/common/models/http-message.ts";
+import { isSamlTrace } from "@/common/models/saml-trace.ts";
+import {
+  getAllSessionStorageKeys,
+  getSessionStorageItems,
+  setSessionStorageItem,
+} from "@/common/utils/chrome-storage.ts";
+import { recordSamlTrace } from "./saml-recorder.ts";
+
+vi.mock("@/common/utils/chrome-storage.ts", () => ({
+  getAllSessionStorageKeys: vi.fn(),
+  getSessionStorageItems: vi.fn(),
+  setSessionStorageItem: vi.fn(),
+}));
+
+let storage: Record<string, unknown>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  storage = {};
+  vi.mocked(getAllSessionStorageKeys).mockImplementation(async () => Object.keys(storage));
+  vi.mocked(getSessionStorageItems).mockImplementation(async (keys) =>
+    Object.fromEntries(keys.filter((k) => k in storage).map((k) => [k, storage[k]])),
+  );
+  vi.mocked(setSessionStorageItem).mockImplementation(async (key, value) => {
+    storage[key] = value;
+  });
+});
+
+function storedFlowEntries(): FlowEntry[] {
+  return Object.values(storage).filter((v): v is FlowEntry => isFlowEntry(v));
+}
+
+function makeResponse(): HttpResponse {
+  return {
+    createdAt: "2026-01-01T00:00:00Z",
+    imported: false,
+    stage: "Response",
+    fetchRequestId: "req-1",
+    headers: [{ name: "Date", value: "Thu, 01 Jan 2026 00:00:00 GMT" }],
+    url: "https://sp.example.com/login",
+    method: "GET",
+    statusCode: 200,
+    body: "",
+  } as unknown as HttpResponse;
+}
+
+describe("recordSamlTrace", () => {
+  it("issues a flow for an unknown correlation key and stores the trace", async () => {
+    const result = await recordSamlTrace(
+      "cs-1",
+      1,
+      { step: 2, correlationKey: "authn-req-1" },
+      makeResponse(),
+    );
+
+    expect(result).toBeUndefined();
+    expect(storedFlowEntries()).toEqual([
+      expect.objectContaining({
+        captureSessionId: "cs-1",
+        protocol: "saml",
+        correlationKey: "authn-req-1",
+      }),
+    ]);
+    expect(Object.values(storage).filter((v) => isSamlTrace(v))).toHaveLength(1);
+  });
+
+  it("reuses the flow of the same correlation key", async () => {
+    await recordSamlTrace("cs-1", 1, { step: 2, correlationKey: "authn-req-1" }, makeResponse());
+    await recordSamlTrace("cs-1", 1, { step: 6, correlationKey: "authn-req-1" }, makeResponse());
+
+    expect(storedFlowEntries()).toHaveLength(1);
+  });
+
+  it("issues a flow per capture session", async () => {
+    await recordSamlTrace("cs-1", 1, { step: 2, correlationKey: "authn-req-1" }, makeResponse());
+    await recordSamlTrace("cs-2", 1, { step: 2, correlationKey: "authn-req-1" }, makeResponse());
+
+    expect(storedFlowEntries().map((f) => f.captureSessionId)).toEqual(["cs-1", "cs-2"]);
+  });
+
+  it("returns an error when the trace cannot be built", async () => {
+    const httpResponse = { ...makeResponse(), url: "not a url" } as HttpResponse;
+
+    const result = await recordSamlTrace(
+      "cs-1",
+      1,
+      { step: 2, correlationKey: "authn-req-1" },
+      httpResponse,
+    );
+
+    expect(result).toBeInstanceOf(Error);
+  });
+
+  it("propagates an error from the storage", async () => {
+    const error = new Error("storage failed");
+    vi.mocked(setSessionStorageItem).mockResolvedValue(error);
+
+    const result = await recordSamlTrace(
+      "cs-1",
+      1,
+      { step: 2, correlationKey: "authn-req-1" },
+      makeResponse(),
+    );
+
+    expect(result).toBe(error);
+  });
+});

--- a/src/common/services/saml-recorder.test.ts
+++ b/src/common/services/saml-recorder.test.ts
@@ -41,6 +41,7 @@ function storedFlowEntries(): FlowEntry[] {
 
 function makeResponse(): HttpResponse {
   return {
+    id: "msg-1",
     createdAt: "2026-01-01T00:00:00Z",
     imported: false,
     stage: "Response",
@@ -70,7 +71,9 @@ describe("recordSamlTrace", () => {
         correlationKey: "authn-req-1",
       }),
     ]);
-    expect(Object.values(storage).filter((v) => isSamlTrace(v))).toHaveLength(1);
+    const samlTraces = Object.values(storage).filter((v) => isSamlTrace(v));
+    expect(samlTraces).toHaveLength(1);
+    expect(samlTraces[0]).toMatchObject({ flowId: storedFlowEntries()[0]!.id });
   });
 
   it("reuses the flow of the same correlation key", async () => {

--- a/src/common/services/saml-recorder.ts
+++ b/src/common/services/saml-recorder.ts
@@ -21,7 +21,7 @@ export async function recordSamlTrace(
     return flowEntry;
   }
 
-  const samlTrace = newSamlTrace(detection, httpMessage);
+  const samlTrace = newSamlTrace(flowEntry.id, detection, httpMessage);
   if (samlTrace instanceof Error) {
     return samlTrace;
   }

--- a/src/common/services/saml-recorder.ts
+++ b/src/common/services/saml-recorder.ts
@@ -1,0 +1,63 @@
+/**
+ * @copyright Internet Initiative Japan Inc. All rights reserved.
+ * @license BSD-3-Clause
+ */
+
+import { type FlowEntry, newFlowEntry } from "@/common/models/flow-entry.ts";
+import { type HttpMessage } from "@/common/models/http-message.ts";
+import { type SamlDetection } from "@/common/models/saml-detection.ts";
+import { debugSamlTrace, newSamlTrace } from "@/common/models/saml-trace.ts";
+import { findFlowEntryByCorrelationKey, saveFlowEntry } from "@/common/services/flow-store.ts";
+import { storeSamlTrace } from "@/common/services/saml-store.ts";
+
+export async function recordSamlTrace(
+  captureSessionId: string,
+  tabId: number,
+  detection: SamlDetection,
+  httpMessage: HttpMessage,
+): Promise<void | Error> {
+  const flowEntry = await findOrIssueFlowEntry(captureSessionId, detection.correlationKey);
+  if (flowEntry instanceof Error) {
+    return flowEntry;
+  }
+
+  const samlTrace = newSamlTrace(detection, httpMessage);
+  if (samlTrace instanceof Error) {
+    return samlTrace;
+  }
+
+  const storeError = await storeSamlTrace(samlTrace, tabId);
+  if (storeError) {
+    return storeError;
+  }
+
+  await debugSamlTrace(samlTrace);
+}
+
+async function findOrIssueFlowEntry(
+  captureSessionId: string,
+  correlationKey: string,
+): Promise<FlowEntry | Error> {
+  const flowEntry = await findFlowEntryByCorrelationKey(captureSessionId, correlationKey);
+  if (flowEntry instanceof Error) {
+    return flowEntry;
+  }
+
+  return flowEntry === undefined
+    ? await issueFlowEntry(captureSessionId, correlationKey)
+    : flowEntry;
+}
+
+async function issueFlowEntry(
+  captureSessionId: string,
+  correlationKey: string,
+): Promise<FlowEntry | Error> {
+  const flowEntry = newFlowEntry(captureSessionId, "saml", correlationKey);
+
+  const saveError = await saveFlowEntry(flowEntry);
+  if (saveError) {
+    return saveError;
+  }
+
+  return flowEntry;
+}

--- a/src/common/services/saml-recorder.ts
+++ b/src/common/services/saml-recorder.ts
@@ -4,7 +4,7 @@
  */
 
 import { type FlowEntry, newFlowEntry } from "@/common/models/flow-entry.ts";
-import { type HttpMessage } from "@/common/models/http-message.ts";
+import { type HttpMessage, type HttpRequest } from "@/common/models/http-message.ts";
 import { type SamlDetection } from "@/common/models/saml-detection.ts";
 import { debugSamlTrace, newSamlTrace } from "@/common/models/saml-trace.ts";
 import { findFlowEntryByCorrelationKey, saveFlowEntry } from "@/common/services/flow-store.ts";
@@ -15,7 +15,29 @@ export async function recordSamlTrace(
   tabId: number,
   detection: SamlDetection,
   httpMessage: HttpMessage,
+  pairedHttpRequest?: HttpRequest,
 ): Promise<void | Error> {
+  if (detection.step === 2) {
+    if (pairedHttpRequest === undefined) {
+      console.warn("No paired HTTP request for the AuthnRequest, skipping step 1:", {
+        correlationKey: detection.correlationKey,
+      });
+    } else {
+      const recordError = await recordSamlTrace(
+        captureSessionId,
+        tabId,
+        {
+          step: 1,
+          correlationKey: detection.correlationKey,
+        },
+        pairedHttpRequest,
+      );
+      if (recordError) {
+        return recordError;
+      }
+    }
+  }
+
   const flowEntry = await findOrIssueFlowEntry(captureSessionId, detection.correlationKey);
   if (flowEntry instanceof Error) {
     return flowEntry;

--- a/src/common/services/saml-recorder.ts
+++ b/src/common/services/saml-recorder.ts
@@ -8,7 +8,7 @@ import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlDetection } from "@/common/models/saml-detection.ts";
 import { debugSamlTrace, newSamlTrace } from "@/common/models/saml-trace.ts";
 import { findFlowEntryByCorrelationKey, saveFlowEntry } from "@/common/services/flow-store.ts";
-import { storeSamlTrace } from "@/common/services/saml-store.ts";
+import { saveSamlTrace } from "@/common/services/saml-store.ts";
 
 export async function recordSamlTrace(
   captureSessionId: string,
@@ -26,9 +26,9 @@ export async function recordSamlTrace(
     return samlTrace;
   }
 
-  const storeError = await storeSamlTrace(samlTrace, tabId);
-  if (storeError) {
-    return storeError;
+  const saveError = await saveSamlTrace(samlTrace, tabId);
+  if (saveError) {
+    return saveError;
   }
 
   await debugSamlTrace(samlTrace);

--- a/src/common/services/saml-store.test.ts
+++ b/src/common/services/saml-store.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @copyright Internet Initiative Japan Inc. All rights reserved.
+ * @license BSD-3-Clause
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type SamlTrace } from "@/common/models/saml-trace.ts";
+import {
+  getAllSessionStorageKeys,
+  getSessionStorageItems,
+  removeSessionStorageItems,
+  setSessionStorageItem,
+} from "@/common/utils/chrome-storage.ts";
+import { deleteSamlTraces, findSamlTraces, saveSamlTrace } from "./saml-store.ts";
+
+vi.mock("@/common/utils/chrome-storage.ts", () => ({
+  getAllSessionStorageKeys: vi.fn(),
+  getSessionStorageItems: vi.fn(),
+  removeSessionStorageItems: vi.fn(),
+  setSessionStorageItem: vi.fn(),
+}));
+
+let storage: Record<string, unknown>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  storage = {};
+  vi.mocked(getAllSessionStorageKeys).mockImplementation(async () => Object.keys(storage));
+  vi.mocked(getSessionStorageItems).mockImplementation(async (keys) =>
+    Object.fromEntries(keys.filter((k) => k in storage).map((k) => [k, storage[k]])),
+  );
+  vi.mocked(removeSessionStorageItems).mockImplementation(async (keys) => {
+    for (const key of keys) {
+      delete storage[key];
+    }
+  });
+  vi.mocked(setSessionStorageItem).mockImplementation(async (key, value) => {
+    storage[key] = value;
+  });
+});
+
+function makeTrace(overrides: Record<string, unknown> = {}): SamlTrace {
+  return {
+    id: "trace-1",
+    flowId: "flow-1",
+    httpMessageId: "msg-1",
+    observedAt: "2026-01-01T00:00:00Z",
+    serverHostname: "sp.example.com",
+    sessionId: "session-1",
+    createdAt: "2026-01-01T00:00:00Z",
+    imported: false,
+    action: "test action",
+    step: 2,
+    type: "IncomingAuthnRequest",
+    ...overrides,
+  } as unknown as SamlTrace;
+}
+
+describe("saveSamlTrace", () => {
+  it("stores the trace under a JSON key with id, kind, tabId, and flowId", async () => {
+    const result = await saveSamlTrace(makeTrace(), 1);
+
+    expect(result).toBeUndefined();
+    expect(storage).toEqual({
+      '{"id":"trace-1","kind":"trace","tabId":1,"flowId":"flow-1"}': makeTrace(),
+    });
+  });
+
+  it("keeps traces of the same step as separate records", async () => {
+    await saveSamlTrace(makeTrace({ id: "trace-1", step: 2 }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-2", step: 2 }), 1);
+
+    expect(await findSamlTraces(1)).toHaveLength(2);
+  });
+});
+
+describe("findSamlTraces", () => {
+  it("returns the traces of the tab in id order", async () => {
+    await saveSamlTrace(makeTrace({ id: "trace-2" }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-1" }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-3" }), 2);
+    storage["other-key"] = { some: "value" };
+
+    const result = await findSamlTraces(1);
+
+    expect(result).not.toBeInstanceOf(Error);
+    expect((result as SamlTrace[]).map((t) => t.id)).toEqual(["trace-1", "trace-2"]);
+  });
+
+  it("filters by the session ID when given", async () => {
+    await saveSamlTrace(makeTrace({ id: "trace-1", sessionId: "session-1" }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-2", sessionId: "session-2" }), 1);
+
+    const result = await findSamlTraces(1, "session-2");
+
+    expect((result as SamlTrace[]).map((t) => t.id)).toEqual(["trace-2"]);
+  });
+
+  it("skips an invalid stored value with a warning", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    storage['{"id":"trace-1","kind":"trace","tabId":1,"flowId":"flow-1"}'] = { broken: true };
+    await saveSamlTrace(makeTrace({ id: "trace-2" }), 1);
+
+    const result = await findSamlTraces(1);
+
+    expect((result as SamlTrace[]).map((t) => t.id)).toEqual(["trace-2"]);
+    expect(consoleWarn).toHaveBeenCalledOnce();
+  });
+
+  it("propagates an error from the storage", async () => {
+    const error = new Error("storage error");
+    vi.mocked(getAllSessionStorageKeys).mockResolvedValue(error);
+
+    expect(await findSamlTraces(1)).toBe(error);
+  });
+});
+
+describe("deleteSamlTraces", () => {
+  it("removes only the traces of the tab and session", async () => {
+    await saveSamlTrace(makeTrace({ id: "trace-1", sessionId: "session-1" }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-2", sessionId: "session-2" }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-3", sessionId: "session-1" }), 2);
+
+    const result = await deleteSamlTraces(1, "session-1");
+
+    expect(result).toBeUndefined();
+    expect(((await findSamlTraces(1)) as SamlTrace[]).map((t) => t.id)).toEqual(["trace-2"]);
+    expect(((await findSamlTraces(2)) as SamlTrace[]).map((t) => t.id)).toEqual(["trace-3"]);
+  });
+});

--- a/src/common/services/saml-store.test.ts
+++ b/src/common/services/saml-store.test.ts
@@ -48,7 +48,6 @@ function makeTrace(overrides: Record<string, unknown> = {}): SamlTrace {
     observedAt: "2026-01-01T00:00:00Z",
     serverHostname: "sp.example.com",
     sessionId: "session-1",
-    createdAt: "2026-01-01T00:00:00Z",
     imported: false,
     action: "test action",
     step: 2,
@@ -86,15 +85,6 @@ describe("findSamlTraces", () => {
 
     expect(result).not.toBeInstanceOf(Error);
     expect((result as SamlTrace[]).map((t) => t.id)).toEqual(["trace-1", "trace-2"]);
-  });
-
-  it("filters by the session ID when given", async () => {
-    await saveSamlTrace(makeTrace({ id: "trace-1", sessionId: "session-1" }), 1);
-    await saveSamlTrace(makeTrace({ id: "trace-2", sessionId: "session-2" }), 1);
-
-    const result = await findSamlTraces(1, "session-2");
-
-    expect((result as SamlTrace[]).map((t) => t.id)).toEqual(["trace-2"]);
   });
 
   it("skips an invalid stored value with a warning", async () => {

--- a/src/common/services/saml-store.ts
+++ b/src/common/services/saml-store.ts
@@ -4,52 +4,105 @@
  */
 
 import { type SamlTrace, isSamlTrace } from "@/common/models/saml-trace.ts";
-import { makeStorageKey, makeStorageKeyPrefix } from "@/common/services/storage-key.ts";
 import {
-  getSessionStorageItemsByKeyPrefix,
-  removeSessionStorageItemsByKeyPrefix,
+  getAllSessionStorageKeys,
+  getSessionStorageItems,
+  removeSessionStorageItems,
   setSessionStorageItem,
 } from "@/common/utils/chrome-storage.ts";
+import { isObject } from "@/common/utils/type-guard.ts";
 
-const STORAGE_NAMESPACE = "saml";
-
-function makeStorageKeyForSamlTrace(tabId: number, sessionId: string, step: number): string {
-  return makeStorageKey(STORAGE_NAMESPACE, [`${tabId}`, sessionId, `${step}`]);
+export async function saveSamlTrace(samlTrace: SamlTrace, tabId: number): Promise<void | Error> {
+  return await setSessionStorageItem(makeSamlTraceKey(samlTrace, tabId), samlTrace);
 }
 
-function makeStorageKeyPrefixForSamlTraces(tabId: number, sessionId?: string): string {
-  const segments = sessionId !== undefined ? [`${tabId}`, sessionId] : [`${tabId}`];
-  return makeStorageKeyPrefix(STORAGE_NAMESPACE, segments);
+export async function deleteSamlTraces(tabId: number, sessionId: string): Promise<void | Error> {
+  const entries = await findSamlTraceEntriesBy((k) => k.tabId === tabId);
+  if (entries instanceof Error) {
+    return entries;
+  }
+
+  const keys = entries
+    .filter(([, samlTrace]) => samlTrace.sessionId === sessionId)
+    .map(([key]) => key);
+  return await removeSessionStorageItems(keys);
 }
 
-export async function storeSamlTrace(samlTrace: SamlTrace, tabId: number): Promise<void | Error> {
-  const key = makeStorageKeyForSamlTrace(tabId, samlTrace.sessionId, samlTrace.step);
-  return await setSessionStorageItem(key, samlTrace);
-}
-
-export async function retrieveSamlTraces(
+export async function findSamlTraces(
   tabId: number,
   sessionId?: string,
 ): Promise<SamlTrace[] | Error> {
-  const keyPrefix = makeStorageKeyPrefixForSamlTraces(tabId, sessionId);
-  const items = await getSessionStorageItemsByKeyPrefix(keyPrefix);
+  const entries = await findSamlTraceEntriesBy((k) => k.tabId === tabId);
+  if (entries instanceof Error) {
+    return entries;
+  }
+
+  const samlTraces = entries.map(([, samlTrace]) => samlTrace);
+  return sessionId === undefined ? samlTraces : samlTraces.filter((t) => t.sessionId === sessionId);
+}
+
+async function findSamlTraceEntriesBy(
+  predicate: (keyFields: SamlTraceKeyFields) => boolean,
+): Promise<[string, SamlTrace][] | Error> {
+  const allKeys = await getAllSessionStorageKeys();
+  if (allKeys instanceof Error) {
+    return allKeys;
+  }
+
+  const keys = allKeys.filter((k) => {
+    const keyFields = parseSamlTraceKey(k);
+    return keyFields !== undefined && predicate(keyFields);
+  });
+
+  const items = await getSessionStorageItems(keys);
   if (items instanceof Error) {
     return items;
   }
 
-  return Object.keys(items)
-    .toSorted()
-    .map((k) => items[k])
-    .filter((u: unknown): u is SamlTrace => {
-      const valid = isSamlTrace(u);
+  return Object.entries(items)
+    .filter((entry): entry is [string, SamlTrace] => {
+      const valid = isSamlTrace(entry[1]);
       if (!valid) {
-        console.warn("Invalid SAML trace:", u);
+        console.warn("Invalid SAML trace:", entry[1]);
       }
       return valid;
-    });
+    })
+    .toSorted(([, a], [, b]) => (a.id < b.id ? -1 : 1));
 }
 
-export async function purgeSamlTraces(tabId: number, sessionId: string): Promise<void | Error> {
-  const keyPrefix = makeStorageKeyPrefixForSamlTraces(tabId, sessionId);
-  return await removeSessionStorageItemsByKeyPrefix(keyPrefix);
+const samlTraceKind = "trace";
+
+type SamlTraceKeyFields = {
+  id: string;
+  kind: typeof samlTraceKind;
+  tabId: number;
+  flowId: string;
+};
+
+function isSamlTraceKeyFields(u: unknown): u is SamlTraceKeyFields {
+  return (
+    isObject(u) &&
+    typeof u.id === "string" &&
+    u.kind === samlTraceKind &&
+    typeof u.tabId === "number" &&
+    typeof u.flowId === "string"
+  );
+}
+
+function makeSamlTraceKey(samlTrace: SamlTrace, tabId: number): string {
+  return JSON.stringify({ ...samlTrace, kind: samlTraceKind, tabId }, [
+    "id",
+    "kind",
+    "tabId",
+    "flowId",
+  ]);
+}
+
+function parseSamlTraceKey(key: string): SamlTraceKeyFields | undefined {
+  try {
+    const parsed: unknown = JSON.parse(key);
+    return isSamlTraceKeyFields(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/src/common/services/saml-store.ts
+++ b/src/common/services/saml-store.ts
@@ -28,17 +28,13 @@ export async function deleteSamlTraces(tabId: number, sessionId: string): Promis
   return await removeSessionStorageItems(keys);
 }
 
-export async function findSamlTraces(
-  tabId: number,
-  sessionId?: string,
-): Promise<SamlTrace[] | Error> {
+export async function findSamlTraces(tabId: number): Promise<SamlTrace[] | Error> {
   const entries = await findSamlTraceEntriesBy((k) => k.tabId === tabId);
   if (entries instanceof Error) {
     return entries;
   }
 
-  const samlTraces = entries.map(([, samlTrace]) => samlTrace);
-  return sessionId === undefined ? samlTraces : samlTraces.filter((t) => t.sessionId === sessionId);
+  return entries.map(([, samlTrace]) => samlTrace);
 }
 
 async function findSamlTraceEntriesBy(

--- a/src/common/services/saml-summarizer.test.ts
+++ b/src/common/services/saml-summarizer.test.ts
@@ -5,11 +5,11 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
-import { retrieveSamlTraces } from "@/common/services/saml-store.ts";
+import { findSamlTraces } from "@/common/services/saml-store.ts";
 import { getSamlSessionSummary, summarizeSamlSession } from "./saml-summarizer.ts";
 
 vi.mock("@/common/services/saml-store.ts", () => ({
-  retrieveSamlTraces: vi.fn(),
+  findSamlTraces: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -50,8 +50,8 @@ function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
 //
 
 describe("getSamlSessionSummary", () => {
-  it("returns Error when retrieveSamlTraces fails", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue(new Error("storage error"));
+  it("returns Error when findSamlTraces fails", async () => {
+    vi.mocked(findSamlTraces).mockResolvedValue(new Error("storage error"));
 
     const result = await getSamlSessionSummary(1, "session-1");
 
@@ -60,7 +60,7 @@ describe("getSamlSessionSummary", () => {
   });
 
   it("returns Error when no messages exist", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([]);
+    vi.mocked(findSamlTraces).mockResolvedValue([]);
 
     const result = await getSamlSessionSummary(1, "session-1");
 
@@ -69,7 +69,7 @@ describe("getSamlSessionSummary", () => {
   });
 
   it("builds summary from a single message", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTraces).mockResolvedValue([
       makeSamlTrace({
         step: 2,
         type: "IncomingAuthnRequest",
@@ -98,7 +98,7 @@ describe("getSamlSessionSummary", () => {
   });
 
   it("sets status to in_progress before AuthenticatedResourceResponse", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTraces).mockResolvedValue([
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
       makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest" }),
       makeSamlTrace({ step: 4, type: "IncomingResponse" }),
@@ -111,7 +111,7 @@ describe("getSamlSessionSummary", () => {
   });
 
   it("sets status to succeeded when AuthenticatedResourceResponse is present", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTraces).mockResolvedValue([
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
       makeSamlTrace({ step: 6, type: "AuthenticatedResourceResponse" }),
     ]);
@@ -123,7 +123,7 @@ describe("getSamlSessionSummary", () => {
   });
 
   it("sets end only when status is succeeded", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTraces).mockResolvedValue([
       makeSamlTrace({
         step: 2,
         type: "IncomingAuthnRequest",
@@ -146,7 +146,7 @@ describe("getSamlSessionSummary", () => {
   });
 
   it("does not set end when status is in_progress", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTraces).mockResolvedValue([
       makeSamlTrace({
         step: 2,
         type: "IncomingAuthnRequest",
@@ -162,7 +162,7 @@ describe("getSamlSessionSummary", () => {
   });
 
   it("sets imported to true if any message is imported", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTraces).mockResolvedValue([
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest", imported: false }),
       makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest", imported: true }),
     ]);
@@ -174,7 +174,7 @@ describe("getSamlSessionSummary", () => {
   });
 
   it("takes sp and idp from the first message that has them", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTraces).mockResolvedValue([
       makeSamlTrace({
         step: 2,
         type: "IncomingAuthnRequest",
@@ -196,7 +196,7 @@ describe("getSamlSessionSummary", () => {
   });
 
   it("sets action to the last message's action", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTraces).mockResolvedValue([
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest", action: "first action" }),
       makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest", action: "second action" }),
       makeSamlTrace({ step: 4, type: "IncomingResponse", action: "third action" }),
@@ -208,14 +208,14 @@ describe("getSamlSessionSummary", () => {
     expect(result).toMatchObject({ action: "third action" });
   });
 
-  it("passes tabId and sessionId to retrieveSamlTraces", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([
+  it("passes tabId and sessionId to findSamlTraces", async () => {
+    vi.mocked(findSamlTraces).mockResolvedValue([
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
     ]);
 
     await getSamlSessionSummary(42, "my-session");
 
-    expect(retrieveSamlTraces).toHaveBeenCalledWith(42, "my-session");
+    expect(findSamlTraces).toHaveBeenCalledWith(42, "my-session");
   });
 });
 

--- a/src/common/services/saml-summarizer.test.ts
+++ b/src/common/services/saml-summarizer.test.ts
@@ -3,18 +3,11 @@
  * @license BSD-3-Clause
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import { type CaptureSession } from "@/common/models/capture-session.ts";
+import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
-import { findSamlTraces } from "@/common/services/saml-store.ts";
-import { getSamlSessionSummary, summarizeSamlSession } from "./saml-summarizer.ts";
-
-vi.mock("@/common/services/saml-store.ts", () => ({
-  findSamlTraces: vi.fn(),
-}));
-
-beforeEach(() => {
-  vi.resetAllMocks();
-});
+import { summarizeSamlFlow, summarizeSamlSession } from "./saml-summarizer.ts";
 
 //
 // Helpers
@@ -22,6 +15,11 @@ beforeEach(() => {
 
 function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
   const base = {
+    id: "trace-1",
+    flowId: "flow-1",
+    httpMessageId: "msg-1",
+    observedAt: "2026-01-01T00:00:00.000Z",
+    serverHostname: "sp.example.com",
     sessionId: "session-1",
     createdAt: "2026-01-01T00:00:00Z",
     imported: false,
@@ -31,11 +29,8 @@ function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
     ...overrides,
   };
 
-  // Add default samlStatusCode for IncomingResponse / OutgoingResponse
-  if (
-    (base.type === "IncomingResponse" || base.type === "OutgoingResponse") &&
-    !("samlStatusCode" in base)
-  ) {
+  // Add default samlStatusCode for step 4 / 5
+  if ((base.step === 4 || base.step === 5) && !("samlStatusCode" in base)) {
     return {
       ...base,
       samlStatusCode: "urn:oasis:names:tc:SAML:2.0:status:Success",
@@ -49,185 +44,12 @@ function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
 // Tests
 //
 
-describe("getSamlSessionSummary", () => {
-  it("returns Error when findSamlTraces fails", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue(new Error("storage error"));
-
-    const result = await getSamlSessionSummary(1, "session-1");
-
-    expect(result).toBeInstanceOf(Error);
-    expect((result as Error).message).toBe("storage error");
-  });
-
-  it("returns Error when no messages exist", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([]);
-
-    const result = await getSamlSessionSummary(1, "session-1");
-
-    expect(result).toBeInstanceOf(Error);
-    expect((result as Error).message).toBe("Session not found");
-  });
-
-  it("builds summary from a single message", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([
-      makeSamlTrace({
-        step: 2,
-        type: "IncomingAuthnRequest",
-        date: "2026-01-01T00:00:00.000Z",
-        sp: "sp.example.com",
-        idp: "idp.example.org",
-        action: "Service Provider issues SAML AuthnRequest",
-      }),
-    ]);
-
-    const result = await getSamlSessionSummary(1, "session-1");
-
-    expect(result).not.toBeInstanceOf(Error);
-    expect(result).toMatchObject({
-      protocol: "saml",
-      sessionId: "session-1",
-      imported: false,
-      capturing: false,
-      start: "2026-01-01T00:00:00.000Z",
-      sp: "sp.example.com",
-      idp: "idp.example.org",
-      status: "in_progress",
-      action: "Service Provider issues SAML AuthnRequest",
-      warning: [],
-    });
-  });
-
-  it("sets status to in_progress before AuthenticatedResourceResponse", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([
-      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
-      makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest" }),
-      makeSamlTrace({ step: 4, type: "IncomingResponse" }),
-    ]);
-
-    const result = await getSamlSessionSummary(1, "session-1");
-
-    expect(result).not.toBeInstanceOf(Error);
-    expect(result).toMatchObject({ status: "in_progress" });
-  });
-
-  it("sets status to succeeded when AuthenticatedResourceResponse is present", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([
-      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
-      makeSamlTrace({ step: 6, type: "AuthenticatedResourceResponse" }),
-    ]);
-
-    const result = await getSamlSessionSummary(1, "session-1");
-
-    expect(result).not.toBeInstanceOf(Error);
-    expect(result).toMatchObject({ status: "succeeded" });
-  });
-
-  it("sets end only when status is succeeded", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([
-      makeSamlTrace({
-        step: 2,
-        type: "IncomingAuthnRequest",
-        date: "2026-01-01T00:00:00.000Z",
-      }),
-      makeSamlTrace({
-        step: 6,
-        type: "AuthenticatedResourceResponse",
-        date: "2026-01-01T00:00:05.000Z",
-      }),
-    ]);
-
-    const result = await getSamlSessionSummary(1, "session-1");
-
-    expect(result).not.toBeInstanceOf(Error);
-    expect(result).toMatchObject({
-      start: "2026-01-01T00:00:00.000Z",
-      end: "2026-01-01T00:00:05.000Z",
-    });
-  });
-
-  it("does not set end when status is in_progress", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([
-      makeSamlTrace({
-        step: 2,
-        type: "IncomingAuthnRequest",
-        date: "2026-01-01T00:00:00.000Z",
-      }),
-    ]);
-
-    const result = await getSamlSessionSummary(1, "session-1");
-
-    expect(result).not.toBeInstanceOf(Error);
-    expect(result).toMatchObject({ start: "2026-01-01T00:00:00.000Z" });
-    expect((result as { end?: string }).end).toBeUndefined();
-  });
-
-  it("sets imported to true if any message is imported", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([
-      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest", imported: false }),
-      makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest", imported: true }),
-    ]);
-
-    const result = await getSamlSessionSummary(1, "session-1");
-
-    expect(result).not.toBeInstanceOf(Error);
-    expect(result).toMatchObject({ imported: true });
-  });
-
-  it("takes sp and idp from the first message that has them", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([
-      makeSamlTrace({
-        step: 2,
-        type: "IncomingAuthnRequest",
-        sp: "first-sp.com",
-        idp: "first-idp.com",
-      }),
-      makeSamlTrace({
-        step: 3,
-        type: "OutgoingAuthnRequest",
-        sp: "second-sp.com",
-        idp: "second-idp.com",
-      }),
-    ]);
-
-    const result = await getSamlSessionSummary(1, "session-1");
-
-    expect(result).not.toBeInstanceOf(Error);
-    expect(result).toMatchObject({ sp: "first-sp.com", idp: "first-idp.com" });
-  });
-
-  it("sets action to the last message's action", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([
-      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest", action: "first action" }),
-      makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest", action: "second action" }),
-      makeSamlTrace({ step: 4, type: "IncomingResponse", action: "third action" }),
-    ]);
-
-    const result = await getSamlSessionSummary(1, "session-1");
-
-    expect(result).not.toBeInstanceOf(Error);
-    expect(result).toMatchObject({ action: "third action" });
-  });
-
-  it("passes tabId and sessionId to findSamlTraces", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([
-      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
-    ]);
-
-    await getSamlSessionSummary(42, "my-session");
-
-    expect(findSamlTraces).toHaveBeenCalledWith(42, "my-session");
-  });
-});
-
 describe("summarizeSamlSession", () => {
   it("builds summary from a single trace", () => {
     const result = summarizeSamlSession("session-1", [
       makeSamlTrace({
         step: 2,
         type: "IncomingAuthnRequest",
-        date: "2026-01-01T00:00:00.000Z",
-        sp: "sp.example.com",
-        idp: "idp.example.org",
         action: "Service Provider issues SAML AuthnRequest",
       }),
     ]);
@@ -239,14 +61,24 @@ describe("summarizeSamlSession", () => {
       capturing: false,
       start: "2026-01-01T00:00:00.000Z",
       sp: "sp.example.com",
-      idp: "idp.example.org",
       status: "in_progress",
       action: "Service Provider issues SAML AuthnRequest",
       warning: [],
     });
+    expect(result.idp).toBeUndefined();
   });
 
-  it("sets status to succeeded when AuthenticatedResourceResponse is present", () => {
+  it("sets status to in_progress before step 6", () => {
+    const result = summarizeSamlSession("session-1", [
+      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
+      makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest" }),
+      makeSamlTrace({ step: 4, type: "IncomingResponse" }),
+    ]);
+
+    expect(result).toMatchObject({ status: "in_progress" });
+  });
+
+  it("sets status to succeeded when a step 6 trace is present", () => {
     const result = summarizeSamlSession("session-1", [
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
       makeSamlTrace({ step: 6, type: "AuthenticatedResourceResponse" }),
@@ -255,17 +87,31 @@ describe("summarizeSamlSession", () => {
     expect(result).toMatchObject({ status: "succeeded" });
   });
 
-  it("sets end only when status is succeeded", () => {
+  it("sets status to failed when the samlStatusCode is not Success", () => {
+    const result = summarizeSamlSession("session-1", [
+      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
+      makeSamlTrace({
+        step: 4,
+        type: "IncomingResponse",
+        samlStatusCode: "urn:oasis:names:tc:SAML:2.0:status:Requester",
+      }),
+      makeSamlTrace({ step: 6, type: "AuthenticatedResourceResponse" }),
+    ]);
+
+    expect(result).toMatchObject({ status: "failed" });
+  });
+
+  it("sets start and end from the observedAt", () => {
     const result = summarizeSamlSession("session-1", [
       makeSamlTrace({
         step: 2,
         type: "IncomingAuthnRequest",
-        date: "2026-01-01T00:00:00.000Z",
+        observedAt: "2026-01-01T00:00:00.000Z",
       }),
       makeSamlTrace({
         step: 6,
         type: "AuthenticatedResourceResponse",
-        date: "2026-01-01T00:00:05.000Z",
+        observedAt: "2026-01-01T00:00:05.000Z",
       }),
     ]);
 
@@ -280,7 +126,7 @@ describe("summarizeSamlSession", () => {
       makeSamlTrace({
         step: 2,
         type: "IncomingAuthnRequest",
-        date: "2026-01-01T00:00:00.000Z",
+        observedAt: "2026-01-01T00:00:00.000Z",
       }),
     ]);
 
@@ -297,23 +143,14 @@ describe("summarizeSamlSession", () => {
     expect(result).toMatchObject({ imported: true });
   });
 
-  it("takes sp and idp from the first trace that has them", () => {
+  it("assigns the serverHostname to sp or idp by the step", () => {
     const result = summarizeSamlSession("session-1", [
-      makeSamlTrace({
-        step: 2,
-        type: "IncomingAuthnRequest",
-        sp: "first-sp.com",
-        idp: "first-idp.com",
-      }),
-      makeSamlTrace({
-        step: 3,
-        type: "OutgoingAuthnRequest",
-        sp: "second-sp.com",
-        idp: "second-idp.com",
-      }),
+      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest", serverHostname: "sp.example.com" }),
+      makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest", serverHostname: "idp.example.org" }),
+      makeSamlTrace({ step: 5, type: "OutgoingResponse", serverHostname: "second-sp.com" }),
     ]);
 
-    expect(result).toMatchObject({ sp: "first-sp.com", idp: "first-idp.com" });
+    expect(result).toMatchObject({ sp: "sp.example.com", idp: "idp.example.org" });
   });
 
   it("sets action to the last trace's action", () => {
@@ -324,5 +161,42 @@ describe("summarizeSamlSession", () => {
     ]);
 
     expect(result).toMatchObject({ action: "third action" });
+  });
+});
+
+describe("summarizeSamlFlow", () => {
+  const flowEntry: FlowEntry = {
+    id: "flow-1",
+    captureSessionId: "cs-1",
+    protocol: "saml",
+    correlationKey: "corr-1",
+  };
+
+  it("uses the correlation key of the flow as the session ID", () => {
+    const captureSession: CaptureSession = {
+      id: "cs-1",
+      imported: false,
+      startedAt: "2026-01-01T00:00:00Z",
+    };
+
+    const result = summarizeSamlFlow(flowEntry, captureSession, [
+      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
+    ]);
+
+    expect(result).toMatchObject({ sessionId: "corr-1", imported: false });
+  });
+
+  it("derives imported from the capture session, not from the traces", () => {
+    const captureSession: CaptureSession = {
+      id: "cs-1",
+      imported: true,
+      importedAt: "2026-01-01T00:00:00Z",
+    };
+
+    const result = summarizeSamlFlow(flowEntry, captureSession, [
+      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest", imported: false }),
+    ]);
+
+    expect(result).toMatchObject({ imported: true });
   });
 });

--- a/src/common/services/saml-summarizer.test.ts
+++ b/src/common/services/saml-summarizer.test.ts
@@ -21,7 +21,6 @@ function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
     observedAt: "2026-01-01T00:00:00.000Z",
     serverHostname: "sp.example.com",
     sessionId: "session-1",
-    createdAt: "2026-01-01T00:00:00Z",
     imported: false,
     action: "test action",
     step: 2,

--- a/src/common/services/saml-summarizer.ts
+++ b/src/common/services/saml-summarizer.ts
@@ -5,13 +5,13 @@
 
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { type SessionSummary } from "@/common/models/session-summary.ts";
-import { retrieveSamlTraces } from "@/common/services/saml-store.ts";
+import { findSamlTraces } from "@/common/services/saml-store.ts";
 
 export async function getSamlSessionSummary(
   tabId: number,
   sessionId: string,
 ): Promise<SessionSummary | Error> {
-  const samlTraces = await retrieveSamlTraces(tabId, sessionId);
+  const samlTraces = await findSamlTraces(tabId, sessionId);
   if (samlTraces instanceof Error) {
     return samlTraces;
   }

--- a/src/common/services/saml-summarizer.ts
+++ b/src/common/services/saml-summarizer.ts
@@ -3,24 +3,21 @@
  * @license BSD-3-Clause
  */
 
+import { type CaptureSession } from "@/common/models/capture-session.ts";
+import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { type SessionSummary } from "@/common/models/session-summary.ts";
-import { findSamlTraces } from "@/common/services/saml-store.ts";
 
-export async function getSamlSessionSummary(
-  tabId: number,
-  sessionId: string,
-): Promise<SessionSummary | Error> {
-  const samlTraces = await findSamlTraces(tabId, sessionId);
-  if (samlTraces instanceof Error) {
-    return samlTraces;
-  }
-
-  if (samlTraces.length === 0) {
-    return new Error("Session not found");
-  }
-
-  return summarizeSamlSession(sessionId, samlTraces);
+export function summarizeSamlFlow(
+  flowEntry: FlowEntry,
+  captureSession: CaptureSession,
+  samlTraces: SamlTrace[],
+): SessionSummary {
+  const summary = summarizeSamlSession(flowEntry.correlationKey, samlTraces);
+  return {
+    ...summary,
+    imported: captureSession.imported,
+  };
 }
 
 export function summarizeSamlSession(sessionId: string, samlTraces: SamlTrace[]): SessionSummary {
@@ -38,29 +35,31 @@ function updateSamlSessionSummary(summary: SessionSummary, samlTrace: SamlTrace)
     if (summary.status === "failed") {
       return "failed";
     } else {
-      switch (samlTrace.type) {
-        case "IncomingResponse":
-        case "OutgoingResponse":
+      switch (samlTrace.step) {
+        case 4:
+        case 5:
           if (!samlTrace.samlStatusCode.endsWith(":Success")) {
             return "failed";
           }
           break;
-        case "AuthenticatedResourceResponse":
+        case 6:
           return "succeeded";
       }
       return "in_progress";
     }
   })();
 
+  const role = samlTrace.step === 3 || samlTrace.step === 4 ? "idp" : "sp";
+
   const warning: string[] = [];
 
   return {
     ...summary,
     imported: summary.imported || samlTrace.imported,
-    start: summary.start ?? samlTrace.date,
-    end: summary.end ?? (status !== "in_progress" ? samlTrace.date : undefined),
-    sp: summary.sp ?? samlTrace.sp,
-    idp: summary.idp ?? samlTrace.idp,
+    start: summary.start ?? samlTrace.observedAt,
+    end: summary.end ?? (status !== "in_progress" ? samlTrace.observedAt : undefined),
+    sp: summary.sp ?? (role === "sp" ? samlTrace.serverHostname : undefined),
+    idp: summary.idp ?? (role === "idp" ? samlTrace.serverHostname : undefined),
     status,
     action: samlTrace.action,
     warning: [...summary.warning, ...warning],

--- a/src/common/services/session-archiver.test.ts
+++ b/src/common/services/session-archiver.test.ts
@@ -96,6 +96,7 @@ describe("loadSessionArchive", () => {
       1,
       { step: 3, correlationKey: "session-1" },
       { ...httpMessage, imported: true },
+      undefined,
     );
   });
 
@@ -138,6 +139,13 @@ describe("loadSessionArchive", () => {
       { ...httpMessage, imported: true },
       1,
       "session-1",
+    );
+    expect(recordSamlTrace).toHaveBeenCalledExactlyOnceWith(
+      expect.any(String),
+      1,
+      { step: 6, correlationKey: "session-1" },
+      { ...httpMessage, imported: true },
+      { ...pairedRequest, imported: true },
     );
   });
 

--- a/src/common/services/session-archiver.test.ts
+++ b/src/common/services/session-archiver.test.ts
@@ -12,7 +12,7 @@ import {
   detectSamlStepFromHttpRequest,
   detectSamlStepFromHttpResponse,
 } from "@/common/services/saml-detector.ts";
-import { storeSamlTrace } from "@/common/services/saml-store.ts";
+import { recordSamlTrace } from "@/common/services/saml-recorder.ts";
 import { dumpSessionArchive, loadSessionArchive } from "./session-archiver.ts";
 
 vi.mock("@/common/models/http-archive.ts", () => ({
@@ -34,8 +34,8 @@ vi.mock("@/common/services/saml-detector.ts", () => ({
   detectSamlStepFromHttpResponse: vi.fn(),
 }));
 
-vi.mock("@/common/services/saml-store.ts", () => ({
-  storeSamlTrace: vi.fn(),
+vi.mock("@/common/services/saml-recorder.ts", () => ({
+  recordSamlTrace: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -81,7 +81,7 @@ describe("loadSessionArchive", () => {
       correlationKey: "session-1",
     });
     vi.mocked(storeHttpMessage).mockResolvedValue(undefined);
-    vi.mocked(storeSamlTrace).mockResolvedValue(undefined);
+    vi.mocked(recordSamlTrace).mockResolvedValue(undefined);
 
     const result = await loadSessionArchive(1, "har-string");
 
@@ -91,14 +91,11 @@ describe("loadSessionArchive", () => {
       1,
       "session-1",
     );
-    expect(storeSamlTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: "session-1",
-        step: 3,
-        imported: true,
-        idp: "idp.example.org",
-      }),
+    expect(recordSamlTrace).toHaveBeenCalledWith(
+      expect.any(String),
       1,
+      { step: 3, correlationKey: "session-1" },
+      { ...httpMessage, imported: true },
     );
   });
 
@@ -124,7 +121,7 @@ describe("loadSessionArchive", () => {
       correlationKey: "session-1",
     });
     vi.mocked(storeHttpMessage).mockResolvedValue(undefined);
-    vi.mocked(storeSamlTrace).mockResolvedValue(undefined);
+    vi.mocked(recordSamlTrace).mockResolvedValue(undefined);
 
     await loadSessionArchive(1, "har-string");
 
@@ -160,6 +157,46 @@ describe("loadSessionArchive", () => {
     expect(detectSamlStepFromHttpResponse).not.toHaveBeenCalled();
     expect(storeHttpMessage).not.toHaveBeenCalled();
     expect(consoleError).toHaveBeenCalledOnce();
+  });
+
+  it("records the traces under the imported capture session", async () => {
+    const httpMessage = {
+      stage: "Request",
+      imported: false,
+      url: "https://idp.example.org/sso",
+      method: "GET",
+    } as unknown as HttpMessage;
+    vi.mocked(toHttpMessages).mockReturnValue([httpMessage]);
+    vi.mocked(detectSamlStepFromHttpRequest).mockResolvedValue({
+      step: 3,
+      correlationKey: "session-1",
+    });
+    vi.mocked(storeHttpMessage).mockResolvedValue(undefined);
+    vi.mocked(recordSamlTrace).mockResolvedValue(undefined);
+
+    await loadSessionArchive(1, "har-string");
+
+    const importedRecord = vi.mocked(saveEventRecord).mock.calls[0]![0];
+    expect(vi.mocked(recordSamlTrace).mock.calls[0]![0]).toBe(importedRecord.id);
+  });
+
+  it("aborts when a trace cannot be recorded", async () => {
+    const httpMessage = {
+      stage: "Request",
+      imported: false,
+      url: "https://idp.example.org/sso",
+      method: "GET",
+    } as unknown as HttpMessage;
+    vi.mocked(toHttpMessages).mockReturnValue([httpMessage]);
+    vi.mocked(detectSamlStepFromHttpRequest).mockResolvedValue({
+      step: 3,
+      correlationKey: "session-1",
+    });
+    vi.mocked(storeHttpMessage).mockResolvedValue(undefined);
+    const error = new Error("record error");
+    vi.mocked(recordSamlTrace).mockResolvedValue(error);
+
+    expect(await loadSessionArchive(1, "har-string")).toBe(error);
   });
 
   it("records the import as an event", async () => {
@@ -212,7 +249,7 @@ describe("loadSessionArchive", () => {
       correlationKey: "session-1",
     });
     vi.mocked(storeHttpMessage).mockResolvedValue(undefined);
-    vi.mocked(storeSamlTrace).mockResolvedValue(undefined);
+    vi.mocked(recordSamlTrace).mockResolvedValue(undefined);
 
     const result = await loadSessionArchive(1, "har-string");
 

--- a/src/common/services/session-archiver.ts
+++ b/src/common/services/session-archiver.ts
@@ -11,14 +11,13 @@ import {
   type HttpResponse,
 } from "@/common/models/http-message.ts";
 import { type SamlDetection } from "@/common/models/saml-detection.ts";
-import { newSamlTrace } from "@/common/models/saml-trace.ts";
 import { saveEventRecord } from "@/common/services/event-store.ts";
 import { retrieveHttpMessages, storeHttpMessage } from "@/common/services/http-store.ts";
 import {
   detectSamlStepFromHttpRequest,
   detectSamlStepFromHttpResponse,
 } from "@/common/services/saml-detector.ts";
-import { storeSamlTrace } from "@/common/services/saml-store.ts";
+import { recordSamlTrace } from "@/common/services/saml-recorder.ts";
 
 /**
  * Export session data as an HTTP Archive (HAR) JSON string.
@@ -55,7 +54,9 @@ export async function loadSessionArchive(tabId: number, har: string): Promise<st
     return httpMessages;
   }
 
-  const saveError = await saveEventRecord(newArchiveImportedRecord());
+  const archiveImportedRecord = newArchiveImportedRecord();
+
+  const saveError = await saveEventRecord(archiveImportedRecord);
   if (saveError) {
     return saveError;
   }
@@ -81,12 +82,6 @@ export async function loadSessionArchive(tabId: number, har: string): Promise<st
       imported: true,
     };
 
-    const samlTrace = newSamlTrace(detection, importedHttpMessage);
-    if (samlTrace instanceof Error) {
-      console.error("Failed to build SAML trace from HTTP message:", samlTrace);
-      continue;
-    }
-
     if (httpMessage.stage === "Response") {
       const pairedHttpRequest = findPairedHttpRequest(httpMessage, httpMessages);
       if (pairedHttpRequest !== undefined) {
@@ -110,9 +105,14 @@ export async function loadSessionArchive(tabId: number, har: string): Promise<st
       return httpStoreError;
     }
 
-    const samlStoreError = await storeSamlTrace(samlTrace, tabId);
-    if (samlStoreError) {
-      return samlStoreError;
+    const recordError = await recordSamlTrace(
+      archiveImportedRecord.id,
+      tabId,
+      detection,
+      importedHttpMessage,
+    );
+    if (recordError) {
+      return recordError;
     }
 
     sessionIds.add(detection.correlationKey);

--- a/src/common/services/session-archiver.ts
+++ b/src/common/services/session-archiver.ts
@@ -69,7 +69,12 @@ export async function loadSessionArchive(tabId: number, har: string): Promise<st
   const sessionIds = new Set<string>();
 
   for (const httpMessage of httpMessages) {
-    const detection = await detectSamlStep(httpMessage, httpMessages);
+    const pairedHttpRequest =
+      httpMessage.stage === "Response"
+        ? findPairedHttpRequest(httpMessage, httpMessages)
+        : undefined;
+
+    const detection = await detectSamlStep(httpMessage, pairedHttpRequest);
     if (detection instanceof Error) {
       console.error("Failed to detect SAML flow from HTTP message:", detection);
       continue;
@@ -82,17 +87,22 @@ export async function loadSessionArchive(tabId: number, har: string): Promise<st
       imported: true,
     };
 
-    if (httpMessage.stage === "Response") {
-      const pairedHttpRequest = findPairedHttpRequest(httpMessage, httpMessages);
-      if (pairedHttpRequest !== undefined) {
-        const httpStoreError = await storeHttpMessage(
-          { ...pairedHttpRequest, imported: true },
-          tabId,
-          detection.correlationKey,
-        );
-        if (httpStoreError) {
-          return httpStoreError;
-        }
+    const importedPairedHttpRequest =
+      pairedHttpRequest === undefined
+        ? undefined
+        : {
+            ...pairedHttpRequest,
+            imported: true,
+          };
+
+    if (importedPairedHttpRequest !== undefined) {
+      const httpStoreError = await storeHttpMessage(
+        importedPairedHttpRequest,
+        tabId,
+        detection.correlationKey,
+      );
+      if (httpStoreError) {
+        return httpStoreError;
       }
     }
 
@@ -110,6 +120,7 @@ export async function loadSessionArchive(tabId: number, har: string): Promise<st
       tabId,
       detection,
       importedHttpMessage,
+      importedPairedHttpRequest,
     );
     if (recordError) {
       return recordError;
@@ -123,12 +134,11 @@ export async function loadSessionArchive(tabId: number, har: string): Promise<st
 
 async function detectSamlStep(
   httpMessage: HttpMessage,
-  httpMessages: HttpMessage[],
+  pairedHttpRequest: HttpRequest | undefined,
 ): Promise<SamlDetection | undefined | Error> {
   if (httpMessage.stage === "Request") {
     return detectSamlStepFromHttpRequest(httpMessage);
   } else {
-    const pairedHttpRequest = findPairedHttpRequest(httpMessage, httpMessages);
     if (pairedHttpRequest === undefined) {
       return new Error(`No paired HTTP request for HTTP response: ${httpMessage.id}`);
     }

--- a/src/common/services/session-manager.test.ts
+++ b/src/common/services/session-manager.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { type SessionSummary } from "@/common/models/session-summary.ts";
 import { purgeHttpMessages } from "@/common/services/http-store.ts";
-import { purgeSamlTraces, retrieveSamlTraces } from "@/common/services/saml-store.ts";
+import { deleteSamlTraces, findSamlTraces } from "@/common/services/saml-store.ts";
 import { getSamlSessionSummary } from "@/common/services/saml-summarizer.ts";
 import { isAttached } from "@/common/utils/chrome-debugger.ts";
 import { deleteSession, getSessionSummaries, getSessionSummary } from "./session-manager.ts";
@@ -17,8 +17,8 @@ vi.mock("@/common/services/http-store.ts", () => ({
 }));
 
 vi.mock("@/common/services/saml-store.ts", () => ({
-  purgeSamlTraces: vi.fn(),
-  retrieveSamlTraces: vi.fn(),
+  deleteSamlTraces: vi.fn(),
+  findSamlTraces: vi.fn(),
 }));
 
 vi.mock("@/common/services/saml-summarizer.ts", () => ({
@@ -35,18 +35,18 @@ beforeEach(() => {
 
 describe("deleteSession", () => {
   it("deletes SAML and HTTP messages on success", async () => {
-    vi.mocked(purgeSamlTraces).mockResolvedValue(undefined);
+    vi.mocked(deleteSamlTraces).mockResolvedValue(undefined);
     vi.mocked(purgeHttpMessages).mockResolvedValue(undefined);
 
     const result = await deleteSession(1, "session-1");
 
     expect(result).toBeUndefined();
-    expect(purgeSamlTraces).toHaveBeenCalledWith(1, "session-1");
+    expect(deleteSamlTraces).toHaveBeenCalledWith(1, "session-1");
     expect(purgeHttpMessages).toHaveBeenCalledWith(1, "session-1");
   });
 
-  it("returns Error when purgeSamlTraces fails", async () => {
-    vi.mocked(purgeSamlTraces).mockResolvedValue(new Error("saml purge error"));
+  it("returns Error when deleteSamlTraces fails", async () => {
+    vi.mocked(deleteSamlTraces).mockResolvedValue(new Error("saml purge error"));
 
     const result = await deleteSession(1, "session-1");
 
@@ -56,7 +56,7 @@ describe("deleteSession", () => {
   });
 
   it("succeeds even when purgeHttpMessages fails", async () => {
-    vi.mocked(purgeSamlTraces).mockResolvedValue(undefined);
+    vi.mocked(deleteSamlTraces).mockResolvedValue(undefined);
     vi.mocked(purgeHttpMessages).mockResolvedValue(new Error("http purge error"));
     const warnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -79,7 +79,7 @@ const baseSummary: Omit<SessionSummary, "capturing"> = {
 describe("getSessionSummary", () => {
   it("returns summary with capturing flag", async () => {
     vi.mocked(getSamlSessionSummary).mockResolvedValue(baseSummary as SessionSummary);
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTraces).mockResolvedValue([
       { sessionId: "session-1", createdAt: "2026-01-01T00:00:00Z" },
     ] as SamlTrace[]);
     vi.mocked(isAttached).mockResolvedValue(true);
@@ -106,7 +106,7 @@ describe("getSessionSummaries", () => {
       { sessionId: "session-1", createdAt: "2026-01-01T00:00:00Z" },
       { sessionId: "session-2", createdAt: "2026-01-02T00:00:00Z" },
     ] as SamlTrace[];
-    vi.mocked(retrieveSamlTraces).mockResolvedValue(samlTraces);
+    vi.mocked(findSamlTraces).mockResolvedValue(samlTraces);
     vi.mocked(getSamlSessionSummary).mockImplementation(async (_tabId, sessionId) => {
       return {
         ...baseSummary,
@@ -125,8 +125,8 @@ describe("getSessionSummaries", () => {
     expect(summaries[1]!.sessionId).toBe("session-1");
   });
 
-  it("returns Error when retrieveSamlTraces fails", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue(new Error("storage error"));
+  it("returns Error when findSamlTraces fails", async () => {
+    vi.mocked(findSamlTraces).mockResolvedValue(new Error("storage error"));
 
     const result = await getSessionSummaries(1);
 
@@ -135,7 +135,7 @@ describe("getSessionSummaries", () => {
   });
 
   it("returns empty array when no sessions exist", async () => {
-    vi.mocked(retrieveSamlTraces).mockResolvedValue([]);
+    vi.mocked(findSamlTraces).mockResolvedValue([]);
 
     const result = await getSessionSummaries(1);
 

--- a/src/common/services/session-manager.test.ts
+++ b/src/common/services/session-manager.test.ts
@@ -58,7 +58,6 @@ function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
     observedAt: "2026-01-01T00:00:00.000Z",
     serverHostname: "sp.example.com",
     sessionId: "corr-1",
-    createdAt: "2026-01-01T00:00:00Z",
     imported: false,
     action: "test action",
     step: 2,

--- a/src/common/services/session-manager.test.ts
+++ b/src/common/services/session-manager.test.ts
@@ -4,13 +4,23 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type CaptureSession } from "@/common/models/capture-session.ts";
+import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
-import { type SessionSummary } from "@/common/models/session-summary.ts";
+import { getCaptureSession } from "@/common/services/capture-query.ts";
+import { findFlowEntryById } from "@/common/services/flow-store.ts";
 import { purgeHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTraces, findSamlTraces } from "@/common/services/saml-store.ts";
-import { getSamlSessionSummary } from "@/common/services/saml-summarizer.ts";
 import { isAttached } from "@/common/utils/chrome-debugger.ts";
-import { deleteSession, getSessionSummaries, getSessionSummary } from "./session-manager.ts";
+import { deleteSession, getSessionSummaries } from "./session-manager.ts";
+
+vi.mock("@/common/services/capture-query.ts", () => ({
+  getCaptureSession: vi.fn(),
+}));
+
+vi.mock("@/common/services/flow-store.ts", () => ({
+  findFlowEntryById: vi.fn(),
+}));
 
 vi.mock("@/common/services/http-store.ts", () => ({
   purgeHttpMessages: vi.fn(),
@@ -21,124 +31,201 @@ vi.mock("@/common/services/saml-store.ts", () => ({
   findSamlTraces: vi.fn(),
 }));
 
-vi.mock("@/common/services/saml-summarizer.ts", () => ({
-  getSamlSessionSummary: vi.fn(),
-}));
-
 vi.mock("@/common/utils/chrome-debugger.ts", () => ({
   isAttached: vi.fn(),
 }));
 
 beforeEach(() => {
   vi.resetAllMocks();
+
+  vi.mocked(findSamlTraces).mockResolvedValue([]);
+  vi.mocked(getCaptureSession).mockResolvedValue(undefined);
+  vi.mocked(findFlowEntryById).mockResolvedValue(undefined);
+  vi.mocked(isAttached).mockResolvedValue(false);
+  vi.mocked(deleteSamlTraces).mockResolvedValue(undefined);
+  vi.mocked(purgeHttpMessages).mockResolvedValue(undefined);
+});
+
+//
+// Helpers
+//
+
+function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
+  return {
+    id: "trace-1",
+    flowId: "flow-1",
+    httpMessageId: "msg-1",
+    observedAt: "2026-01-01T00:00:00.000Z",
+    serverHostname: "sp.example.com",
+    sessionId: "corr-1",
+    createdAt: "2026-01-01T00:00:00Z",
+    imported: false,
+    action: "test action",
+    step: 2,
+    type: "IncomingAuthnRequest",
+    ...overrides,
+  } as SamlTrace;
+}
+
+function makeFlowEntry(overrides: Partial<FlowEntry> = {}): FlowEntry {
+  return {
+    id: "flow-1",
+    captureSessionId: "cs-1",
+    protocol: "saml",
+    correlationKey: "corr-1",
+    ...overrides,
+  };
+}
+
+function makeCaptureSession(overrides: Partial<CaptureSession> = {}): CaptureSession {
+  return {
+    id: "cs-1",
+    imported: false,
+    startedAt: "2026-01-01T00:00:00Z",
+    endedAt: "2026-01-01T00:01:00Z",
+    ...overrides,
+  } as CaptureSession;
+}
+
+//
+// Tests
+//
+
+describe("getSessionSummaries", () => {
+  it("returns an empty array when no traces exist", async () => {
+    expect(await getSessionSummaries(1)).toEqual([]);
+  });
+
+  it("builds one summary per flow, newest flow first", async () => {
+    vi.mocked(findSamlTraces).mockResolvedValue([
+      makeSamlTrace({ id: "trace-1", flowId: "flow-1", step: 2, action: "first action" }),
+      makeSamlTrace({ id: "trace-2", flowId: "flow-1", step: 3, action: "second action" }),
+      makeSamlTrace({ id: "trace-3", flowId: "flow-2", step: 2, action: "other action" }),
+    ]);
+    vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession());
+    vi.mocked(findFlowEntryById).mockImplementation(async (id) =>
+      id === "flow-1"
+        ? makeFlowEntry({ id: "flow-1", correlationKey: "corr-1" })
+        : makeFlowEntry({ id: "flow-2", correlationKey: "corr-2" }),
+    );
+
+    const result = await getSessionSummaries(1);
+
+    expect(result).not.toBeInstanceOf(Error);
+    expect(result).toMatchObject([
+      { sessionId: "corr-2", action: "other action" },
+      { sessionId: "corr-1", action: "second action" },
+    ]);
+  });
+
+  it("derives imported from the capture session", async () => {
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({ imported: false })]);
+    vi.mocked(getCaptureSession).mockResolvedValue(
+      makeCaptureSession({ imported: true, importedAt: "2026-01-01T00:00:00Z" }),
+    );
+    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+
+    const result = await getSessionSummaries(1);
+
+    expect(result).toMatchObject([{ imported: true, capturing: false }]);
+  });
+
+  it("sets capturing when the capture session is ongoing and the debugger is attached", async () => {
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
+    vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession({ endedAt: undefined }));
+    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+    vi.mocked(isAttached).mockResolvedValue(true);
+
+    expect(await getSessionSummaries(1)).toMatchObject([{ capturing: true }]);
+  });
+
+  it("does not set capturing when the capture session has ended", async () => {
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
+    vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession());
+    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+    vi.mocked(isAttached).mockResolvedValue(true);
+
+    expect(await getSessionSummaries(1)).toMatchObject([{ capturing: false }]);
+  });
+
+  it("does not set capturing when the debugger is not attached", async () => {
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
+    vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession({ endedAt: undefined }));
+    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+    vi.mocked(isAttached).mockResolvedValue(false);
+
+    expect(await getSessionSummaries(1)).toMatchObject([{ capturing: false }]);
+  });
+
+  it("skips traces without a flow entry with a warning", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({ flowId: "flow-x" })]);
+
+    expect(await getSessionSummaries(1)).toEqual([]);
+    expect(consoleWarn).toHaveBeenCalledOnce();
+  });
+
+  it("propagates an error from the trace store", async () => {
+    const error = new Error("trace store error");
+    vi.mocked(findSamlTraces).mockResolvedValue(error);
+
+    expect(await getSessionSummaries(1)).toBe(error);
+  });
+
+  it("propagates an error from the capture session query", async () => {
+    const error = new Error("capture query error");
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
+    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+    vi.mocked(getCaptureSession).mockResolvedValue(error);
+
+    expect(await getSessionSummaries(1)).toBe(error);
+  });
+
+  it("propagates an error from the flow store", async () => {
+    const error = new Error("flow store error");
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
+    vi.mocked(findFlowEntryById).mockResolvedValue(error);
+
+    expect(await getSessionSummaries(1)).toBe(error);
+  });
+
+  it("skips a flow whose capture session is missing with a warning", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
+    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+
+    expect(await getSessionSummaries(1)).toEqual([]);
+    expect(consoleWarn).toHaveBeenCalledOnce();
+  });
+
+  it("propagates an error from the debugger", async () => {
+    const error = new Error("debugger error");
+    vi.mocked(isAttached).mockResolvedValue(error);
+
+    expect(await getSessionSummaries(1)).toBe(error);
+  });
 });
 
 describe("deleteSession", () => {
-  it("deletes SAML and HTTP messages on success", async () => {
-    vi.mocked(deleteSamlTraces).mockResolvedValue(undefined);
-    vi.mocked(purgeHttpMessages).mockResolvedValue(undefined);
-
-    const result = await deleteSession(1, "session-1");
-
-    expect(result).toBeUndefined();
-    expect(deleteSamlTraces).toHaveBeenCalledWith(1, "session-1");
-    expect(purgeHttpMessages).toHaveBeenCalledWith(1, "session-1");
+  it("deletes the traces and the HTTP messages", async () => {
+    expect(await deleteSession(1, "corr-1")).toBeUndefined();
+    expect(deleteSamlTraces).toHaveBeenCalledWith(1, "corr-1");
+    expect(purgeHttpMessages).toHaveBeenCalledWith(1, "corr-1");
   });
 
-  it("returns Error when deleteSamlTraces fails", async () => {
-    vi.mocked(deleteSamlTraces).mockResolvedValue(new Error("saml purge error"));
+  it("returns an error when the trace deletion fails", async () => {
+    const error = new Error("saml delete error");
+    vi.mocked(deleteSamlTraces).mockResolvedValue(error);
 
-    const result = await deleteSession(1, "session-1");
-
-    expect(result).toBeInstanceOf(Error);
-    expect((result as Error).message).toBe("saml purge error");
+    expect(await deleteSession(1, "corr-1")).toBe(error);
     expect(purgeHttpMessages).not.toHaveBeenCalled();
   });
 
-  it("succeeds even when purgeHttpMessages fails", async () => {
-    vi.mocked(deleteSamlTraces).mockResolvedValue(undefined);
+  it("ignores a failure of the HTTP message purge", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.mocked(purgeHttpMessages).mockResolvedValue(new Error("http purge error"));
-    const warnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    const result = await deleteSession(1, "session-1");
-
-    expect(result).toBeUndefined();
-    expect(warnMock).toHaveBeenCalled();
-    warnMock.mockRestore();
-  });
-});
-
-const baseSummary: Omit<SessionSummary, "capturing"> = {
-  protocol: "saml",
-  imported: false,
-  sessionId: "session-1",
-  start: "2026-01-01T00:00:00Z",
-  warning: [],
-};
-
-describe("getSessionSummary", () => {
-  it("returns summary with capturing flag", async () => {
-    vi.mocked(getSamlSessionSummary).mockResolvedValue(baseSummary as SessionSummary);
-    vi.mocked(findSamlTraces).mockResolvedValue([
-      { sessionId: "session-1", createdAt: "2026-01-01T00:00:00Z" },
-    ] as SamlTrace[]);
-    vi.mocked(isAttached).mockResolvedValue(true);
-
-    const result = await getSessionSummary(1, "session-1");
-
-    expect(result).not.toBeInstanceOf(Error);
-    expect((result as SessionSummary).capturing).toBe(true);
-  });
-
-  it("returns Error when getSamlSessionSummary fails", async () => {
-    vi.mocked(getSamlSessionSummary).mockResolvedValue(new Error("summary error"));
-
-    const result = await getSessionSummary(1, "session-1");
-
-    expect(result).toBeInstanceOf(Error);
-    expect((result as Error).message).toBe("summary error");
-  });
-});
-
-describe("getSessionSummaries", () => {
-  it("returns summaries sorted by start time in descending order", async () => {
-    const samlTraces = [
-      { sessionId: "session-1", createdAt: "2026-01-01T00:00:00Z" },
-      { sessionId: "session-2", createdAt: "2026-01-02T00:00:00Z" },
-    ] as SamlTrace[];
-    vi.mocked(findSamlTraces).mockResolvedValue(samlTraces);
-    vi.mocked(getSamlSessionSummary).mockImplementation(async (_tabId, sessionId) => {
-      return {
-        ...baseSummary,
-        sessionId,
-        start: sessionId === "session-1" ? "2026-01-01T00:00:00Z" : "2026-01-02T00:00:00Z",
-      } as SessionSummary;
-    });
-    vi.mocked(isAttached).mockResolvedValue(false);
-
-    const result = await getSessionSummaries(1);
-
-    expect(result).not.toBeInstanceOf(Error);
-    const summaries = result as SessionSummary[];
-    expect(summaries).toHaveLength(2);
-    expect(summaries[0]!.sessionId).toBe("session-2");
-    expect(summaries[1]!.sessionId).toBe("session-1");
-  });
-
-  it("returns Error when findSamlTraces fails", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue(new Error("storage error"));
-
-    const result = await getSessionSummaries(1);
-
-    expect(result).toBeInstanceOf(Error);
-    expect((result as Error).message).toBe("storage error");
-  });
-
-  it("returns empty array when no sessions exist", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([]);
-
-    const result = await getSessionSummaries(1);
-
-    expect(result).toEqual([]);
+    expect(await deleteSession(1, "corr-1")).toBeUndefined();
+    expect(consoleWarn).toHaveBeenCalledOnce();
   });
 });

--- a/src/common/services/session-manager.ts
+++ b/src/common/services/session-manager.ts
@@ -5,7 +5,7 @@
 
 import { type SessionSummary, debugSessionSummary } from "@/common/models/session-summary.ts";
 import { purgeHttpMessages } from "@/common/services/http-store.ts";
-import { purgeSamlTraces, retrieveSamlTraces } from "@/common/services/saml-store.ts";
+import { deleteSamlTraces, findSamlTraces } from "@/common/services/saml-store.ts";
 import { getSamlSessionSummary } from "@/common/services/saml-summarizer.ts";
 import { isAttached } from "@/common/utils/chrome-debugger.ts";
 
@@ -42,7 +42,7 @@ export async function getSessionSummaries(tabId: number): Promise<SessionSummary
 }
 
 async function findSessionIds(tabId: number): Promise<string[] | Error> {
-  const samlTraces = await retrieveSamlTraces(tabId);
+  const samlTraces = await findSamlTraces(tabId);
   if (samlTraces instanceof Error) {
     return samlTraces;
   }
@@ -85,7 +85,7 @@ export async function getSessionSummary(
 }
 
 async function findLatestSessionId(tabId: number): Promise<string | undefined | Error> {
-  const messages = await retrieveSamlTraces(tabId);
+  const messages = await findSamlTraces(tabId);
   if (messages instanceof Error) {
     return messages;
   }
@@ -106,7 +106,7 @@ async function findLatestSessionId(tabId: number): Promise<string | undefined | 
  * @returns void on success, or an Error
  */
 export async function deleteSession(tabId: number, sessionId: string): Promise<void | Error> {
-  const samlPurgeError = await purgeSamlTraces(tabId, sessionId);
+  const samlPurgeError = await deleteSamlTraces(tabId, sessionId);
   if (samlPurgeError) {
     return samlPurgeError;
   }

--- a/src/common/services/session-manager.ts
+++ b/src/common/services/session-manager.ts
@@ -3,99 +3,87 @@
  * @license BSD-3-Clause
  */
 
+import { type CaptureSession } from "@/common/models/capture-session.ts";
+import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { type SessionSummary, debugSessionSummary } from "@/common/models/session-summary.ts";
+import { getCaptureSession } from "@/common/services/capture-query.ts";
+import { findFlowEntryById } from "@/common/services/flow-store.ts";
 import { purgeHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTraces, findSamlTraces } from "@/common/services/saml-store.ts";
-import { getSamlSessionSummary } from "@/common/services/saml-summarizer.ts";
+import { summarizeSamlFlow } from "@/common/services/saml-summarizer.ts";
 import { isAttached } from "@/common/utils/chrome-debugger.ts";
 
-// NOTE: getSessionSummaries and getSessionSummary have known inefficiencies
-// (e.g., repeated data fetches), but we prioritize simplicity as performance
-// is not a concern at current scale.
+// NOTE: getSessionSummaries has known inefficiencies (e.g., repeated data
+// fetches), but we prioritize simplicity as performance is not a concern at
+// current scale.
 
 /**
  * Retrieve summaries for all sessions associated with a tab.
  *
  * @param tabId - The tab ID to retrieve session summaries for
- * @returns An array of session summaries sorted by start time in descending order, or an Error
+ * @returns An array of session summaries sorted by flow ID in descending order, or an Error
  */
 export async function getSessionSummaries(tabId: number): Promise<SessionSummary[] | Error> {
-  const sessionIds = await findSessionIds(tabId);
-  if (sessionIds instanceof Error) {
-    return sessionIds;
+  const attached = await isAttached(tabId);
+  if (attached instanceof Error) {
+    return attached;
   }
 
-  const summaries = await Promise.all(sessionIds.map((s) => getSessionSummary(tabId, s)));
-  const summaryError = summaries.find((s): s is Error => s instanceof Error);
-  if (summaryError) {
-    return summaryError;
+  const samlTracesByFlowId = await findSamlTracesGroupedByFlowId(tabId);
+  if (samlTracesByFlowId instanceof Error) {
+    return samlTracesByFlowId;
   }
 
-  return summaries
-    .filter((s): s is SessionSummary => !(s instanceof Error))
-    .sort((a, b) => {
-      if (a.start === undefined) return 1;
-      if (b.start === undefined) return -1;
-      // ISO 8601 format allows lexicographical sorting to match chronological order
-      return b.start.localeCompare(a.start);
-    });
+  const summaries: SessionSummary[] = [];
+  for (const [flowId, samlTraces] of samlTracesByFlowId) {
+    const flowEntry = await findFlowEntryById(flowId);
+    if (flowEntry instanceof Error) {
+      return flowEntry;
+    } else if (flowEntry === undefined) {
+      console.warn("No flow entry for the traces:", { flowId });
+      continue;
+    }
+
+    const captureSession = await getCaptureSession(flowEntry.captureSessionId);
+    if (captureSession instanceof Error) {
+      return captureSession;
+    } else if (captureSession === undefined) {
+      console.warn("No capture session for the flow:", { flowId });
+      continue;
+    }
+
+    const summary = {
+      ...summarizeSamlFlow(flowEntry, captureSession, samlTraces),
+      capturing: isOngoing(captureSession) && attached,
+    };
+
+    summaries.push(summary);
+    await debugSessionSummary(summary);
+  }
+
+  return summaries;
 }
 
-async function findSessionIds(tabId: number): Promise<string[] | Error> {
+async function findSamlTracesGroupedByFlowId(
+  tabId: number,
+): Promise<Map<string, SamlTrace[]> | Error> {
   const samlTraces = await findSamlTraces(tabId);
   if (samlTraces instanceof Error) {
     return samlTraces;
   }
 
-  return [...new Set(samlTraces.map((m) => m.sessionId))];
+  // TODO: Rewrite with Map.groupBy after raising the TypeScript target to ES2024 or later
+  const samlTracesByFlowId = samlTraces.reduce((acc, trace) => {
+    const current = acc.get(trace.flowId) ?? [];
+    acc.set(trace.flowId, [...current, trace]);
+    return acc;
+  }, new Map<string, SamlTrace[]>());
+
+  return new Map([...samlTracesByFlowId.entries()].toSorted(([a], [b]) => (a < b ? 1 : -1)));
 }
 
-/**
- * Retrieve the summary for a specific session.
- *
- * @param tabId - The tab ID associated with the session
- * @param sessionId - The session ID to retrieve the summary for
- * @returns The session summary, or an Error
- */
-export async function getSessionSummary(
-  tabId: number,
-  sessionId: string,
-): Promise<SessionSummary | Error> {
-  const summary = await getSamlSessionSummary(tabId, sessionId);
-  if (summary instanceof Error) {
-    return summary;
-  }
-
-  const latestSessionId = await findLatestSessionId(tabId);
-  if (latestSessionId instanceof Error) {
-    return latestSessionId;
-  }
-  if (latestSessionId === undefined) {
-    console.warn("Latest session ID not found:", { tabId });
-  }
-
-  const capturing = latestSessionId === sessionId && (await isAttached(tabId));
-  if (capturing instanceof Error) {
-    return capturing;
-  }
-
-  await debugSessionSummary({ ...summary, capturing });
-
-  return { ...summary, capturing };
-}
-
-async function findLatestSessionId(tabId: number): Promise<string | undefined | Error> {
-  const messages = await findSamlTraces(tabId);
-  if (messages instanceof Error) {
-    return messages;
-  }
-  if (messages.length === 0) {
-    return undefined;
-  }
-
-  const latest = messages.reduce((a, b) => (a.createdAt > b.createdAt ? a : b));
-
-  return latest.sessionId;
+function isOngoing(captureSession: CaptureSession): boolean {
+  return !captureSession.imported && captureSession.endedAt === undefined;
 }
 
 /**
@@ -106,9 +94,9 @@ async function findLatestSessionId(tabId: number): Promise<string | undefined | 
  * @returns void on success, or an Error
  */
 export async function deleteSession(tabId: number, sessionId: string): Promise<void | Error> {
-  const samlPurgeError = await deleteSamlTraces(tabId, sessionId);
-  if (samlPurgeError) {
-    return samlPurgeError;
+  const samlDeleteError = await deleteSamlTraces(tabId, sessionId);
+  if (samlDeleteError) {
+    return samlDeleteError;
   }
 
   const httpPurgeError = await purgeHttpMessages(tabId, sessionId);

--- a/src/common/utils/chrome-storage.ts
+++ b/src/common/utils/chrome-storage.ts
@@ -52,7 +52,7 @@ export async function getSessionStorageItemsByKeyPrefix(
   return await getSessionStorageItems(keys);
 }
 
-async function removeSessionStorageItems(keys: string[]): Promise<void | Error> {
+export async function removeSessionStorageItems(keys: string[]): Promise<void | Error> {
   try {
     await chrome.storage.session.remove(keys);
   } catch (err) {

--- a/src/report-page/app.tsx
+++ b/src/report-page/app.tsx
@@ -203,7 +203,7 @@ async function buildSamlTraces(httpMessages: HttpMessage[]): Promise<SamlTrace[]
       continue;
     }
 
-    const samlTrace = newSamlTrace(samlDetection, httpMessage);
+    const samlTrace = newSamlTrace(samlDetection.correlationKey, samlDetection, httpMessage);
     if (samlTrace instanceof Error) {
       console.error("Failed to build SAML trace from HTTP message:", samlTrace);
       continue;

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -32,7 +32,7 @@ import {
   stopCapturing,
 } from "@/service-worker/capture-manager.ts";
 import { registerHttpInterceptionHandlers } from "@/service-worker/http-interception.ts";
-import { processHttpRequest, processHttpResponse } from "@/service-worker/saml-recorder.ts";
+import { processHttpRequest, processHttpResponse } from "@/service-worker/saml-tracer.ts";
 import {
   registerSidePanelCloseHandler,
   registerSidePanelOpenHandler,

--- a/src/service-worker/saml-tracer.test.ts
+++ b/src/service-worker/saml-tracer.test.ts
@@ -199,6 +199,7 @@ describe("processHttpResponse", () => {
       1,
       { step: 2, correlationKey: "session-1" },
       response,
+      pairedRequest,
     );
   });
 

--- a/src/service-worker/saml-tracer.test.ts
+++ b/src/service-worker/saml-tracer.test.ts
@@ -10,8 +10,9 @@ import {
   detectSamlStepFromHttpRequest,
   detectSamlStepFromHttpResponse,
 } from "@/common/services/saml-detector.ts";
-import { storeSamlTrace } from "@/common/services/saml-store.ts";
-import { processHttpRequest, processHttpResponse } from "./saml-recorder.ts";
+import { recordSamlTrace } from "@/common/services/saml-recorder.ts";
+import { getOngoingCaptureSessionId } from "@/service-worker/capture-manager.ts";
+import { processHttpRequest, processHttpResponse } from "./saml-tracer.ts";
 
 vi.mock("@/common/services/saml-detector.ts", () => ({
   detectSamlStepFromHttpRequest: vi.fn(),
@@ -22,12 +23,17 @@ vi.mock("@/common/services/http-store.ts", () => ({
   storeHttpMessage: vi.fn(),
 }));
 
-vi.mock("@/common/services/saml-store.ts", () => ({
-  storeSamlTrace: vi.fn(),
+vi.mock("@/common/services/saml-recorder.ts", () => ({
+  recordSamlTrace: vi.fn(),
+}));
+
+vi.mock("@/service-worker/capture-manager.ts", () => ({
+  getOngoingCaptureSessionId: vi.fn(),
 }));
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(getOngoingCaptureSessionId).mockResolvedValue("capture-session-1");
 });
 
 //
@@ -76,7 +82,7 @@ describe("processHttpRequest", () => {
 
     expect(result).toBeUndefined();
     expect(storeHttpMessage).not.toHaveBeenCalled();
-    expect(storeSamlTrace).not.toHaveBeenCalled();
+    expect(recordSamlTrace).not.toHaveBeenCalled();
   });
 
   it("returns Error when detection fails", async () => {
@@ -89,27 +95,25 @@ describe("processHttpRequest", () => {
     expect((result as Error).message).toBe("detection error");
   });
 
-  it("stores HTTP message and SAML trace and returns correlation key on detection", async () => {
+  it("stores the HTTP message and records the trace, and returns the correlation key", async () => {
     const request = makeRequest();
     vi.mocked(detectSamlStepFromHttpRequest).mockResolvedValue({
       step: 3,
       correlationKey: "session-1",
     });
     vi.mocked(storeHttpMessage).mockResolvedValue(undefined);
-    vi.mocked(storeSamlTrace).mockResolvedValue(undefined);
+    vi.mocked(recordSamlTrace).mockResolvedValue(undefined);
 
     const result = await processHttpRequest(1, request);
 
     expect(result).toBe("session-1");
     expect(storeHttpMessage).toHaveBeenCalledTimes(1);
     expect(storeHttpMessage).toHaveBeenCalledWith(request, 1, "session-1");
-    expect(storeSamlTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: "session-1",
-        step: 3,
-        type: "OutgoingAuthnRequest",
-      }),
+    expect(recordSamlTrace).toHaveBeenCalledExactlyOnceWith(
+      "capture-session-1",
       1,
+      { step: 3, correlationKey: "session-1" },
+      request,
     );
   });
 
@@ -125,22 +129,39 @@ describe("processHttpRequest", () => {
 
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("store error");
-    expect(storeSamlTrace).not.toHaveBeenCalled();
+    expect(recordSamlTrace).not.toHaveBeenCalled();
   });
 
-  it("returns Error when storing the SAML trace fails", async () => {
+  it("returns Error when recording the SAML trace fails", async () => {
     const request = makeRequest();
     vi.mocked(detectSamlStepFromHttpRequest).mockResolvedValue({
       step: 3,
       correlationKey: "session-1",
     });
     vi.mocked(storeHttpMessage).mockResolvedValue(undefined);
-    vi.mocked(storeSamlTrace).mockResolvedValue(new Error("saml store error"));
+    vi.mocked(recordSamlTrace).mockResolvedValue(new Error("record error"));
 
     const result = await processHttpRequest(1, request);
 
     expect(result).toBeInstanceOf(Error);
-    expect((result as Error).message).toBe("saml store error");
+    expect((result as Error).message).toBe("record error");
+  });
+
+  it("skips the record when no capture session is ongoing", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const request = makeRequest();
+    vi.mocked(detectSamlStepFromHttpRequest).mockResolvedValue({
+      step: 3,
+      correlationKey: "session-1",
+    });
+    vi.mocked(getOngoingCaptureSessionId).mockResolvedValue(undefined);
+
+    const result = await processHttpRequest(1, request);
+
+    expect(result).toBeUndefined();
+    expect(storeHttpMessage).not.toHaveBeenCalled();
+    expect(recordSamlTrace).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledOnce();
   });
 });
 
@@ -165,7 +186,7 @@ describe("processHttpResponse", () => {
       correlationKey: "session-1",
     });
     vi.mocked(storeHttpMessage).mockResolvedValue(undefined);
-    vi.mocked(storeSamlTrace).mockResolvedValue(undefined);
+    vi.mocked(recordSamlTrace).mockResolvedValue(undefined);
 
     const result = await processHttpResponse(1, response, pairedRequest);
 
@@ -173,13 +194,11 @@ describe("processHttpResponse", () => {
     expect(storeHttpMessage).toHaveBeenCalledTimes(2);
     expect(storeHttpMessage).toHaveBeenNthCalledWith(1, pairedRequest, 1, "session-1");
     expect(storeHttpMessage).toHaveBeenNthCalledWith(2, response, 1, "session-1");
-    expect(storeSamlTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: "session-1",
-        step: 2,
-        type: "IncomingAuthnRequest",
-      }),
+    expect(recordSamlTrace).toHaveBeenCalledExactlyOnceWith(
+      "capture-session-1",
       1,
+      { step: 2, correlationKey: "session-1" },
+      response,
     );
   });
 
@@ -196,6 +215,6 @@ describe("processHttpResponse", () => {
 
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("store error");
-    expect(storeSamlTrace).not.toHaveBeenCalled();
+    expect(recordSamlTrace).not.toHaveBeenCalled();
   });
 });

--- a/src/service-worker/saml-tracer.ts
+++ b/src/service-worker/saml-tracer.ts
@@ -83,7 +83,13 @@ export async function processHttpResponse(
     return httpStoreError;
   }
 
-  const recordError = await recordSamlTrace(captureSessionId, tabId, detection, httpResponse);
+  const recordError = await recordSamlTrace(
+    captureSessionId,
+    tabId,
+    detection,
+    httpResponse,
+    pairedHttpRequest,
+  );
   if (recordError) {
     return recordError;
   }

--- a/src/service-worker/saml-tracer.ts
+++ b/src/service-worker/saml-tracer.ts
@@ -9,13 +9,13 @@ import {
   debugHttpRequest,
   debugHttpResponse,
 } from "@/common/models/http-message.ts";
-import { debugSamlTrace, newSamlTrace } from "@/common/models/saml-trace.ts";
 import { storeHttpMessage } from "@/common/services/http-store.ts";
 import {
   detectSamlStepFromHttpRequest,
   detectSamlStepFromHttpResponse,
 } from "@/common/services/saml-detector.ts";
-import { storeSamlTrace } from "@/common/services/saml-store.ts";
+import { recordSamlTrace } from "@/common/services/saml-recorder.ts";
+import { getOngoingCaptureSessionId } from "@/service-worker/capture-manager.ts";
 
 export async function processHttpRequest(
   tabId: number,
@@ -30,9 +30,12 @@ export async function processHttpRequest(
     return undefined;
   }
 
-  const samlTrace = newSamlTrace(detection, httpRequest);
-  if (samlTrace instanceof Error) {
-    return samlTrace;
+  const captureSessionId = await getOngoingCaptureSessionId();
+  if (captureSessionId instanceof Error) {
+    return captureSessionId;
+  } else if (captureSessionId === undefined) {
+    console.warn("No ongoing capture session, skipping the HTTP request:", { tabId });
+    return undefined;
   }
 
   const httpStoreError = await storeHttpMessage(httpRequest, tabId, detection.correlationKey);
@@ -40,12 +43,10 @@ export async function processHttpRequest(
     return httpStoreError;
   }
 
-  const samlStoreError = await storeSamlTrace(samlTrace, tabId);
-  if (samlStoreError) {
-    return samlStoreError;
+  const recordError = await recordSamlTrace(captureSessionId, tabId, detection, httpRequest);
+  if (recordError) {
+    return recordError;
   }
-
-  await debugSamlTrace(samlTrace);
 
   return detection.correlationKey;
 }
@@ -64,9 +65,12 @@ export async function processHttpResponse(
     return undefined;
   }
 
-  const samlTrace = newSamlTrace(detection, httpResponse);
-  if (samlTrace instanceof Error) {
-    return samlTrace;
+  const captureSessionId = await getOngoingCaptureSessionId();
+  if (captureSessionId instanceof Error) {
+    return captureSessionId;
+  } else if (captureSessionId === undefined) {
+    console.warn("No ongoing capture session, skipping the HTTP response:", { tabId });
+    return undefined;
   }
 
   const pairStoreError = await storeHttpMessage(pairedHttpRequest, tabId, detection.correlationKey);
@@ -79,12 +83,10 @@ export async function processHttpResponse(
     return httpStoreError;
   }
 
-  const samlStoreError = await storeSamlTrace(samlTrace, tabId);
-  if (samlStoreError) {
-    return samlStoreError;
+  const recordError = await recordSamlTrace(captureSessionId, tabId, detection, httpResponse);
+  if (recordError) {
+    return recordError;
   }
-
-  await debugSamlTrace(samlTrace);
 
   return detection.correlationKey;
 }


### PR DESCRIPTION
- **Issue SSO flows when recording SAML traces**
- **Add flow and message references to SamlTrace**
- **Rework SAML trace keys and store API**
- **Build summaries per SSO flow**
- **Issue step 1 traces ahead of step 2**
- **Drop unread attributes from SamlTrace**
