### PR TITLE
Read, delete and export flows through SAML traces

### DIFF
--- a/src/common/models/http-message.test.ts
+++ b/src/common/models/http-message.test.ts
@@ -22,7 +22,6 @@ function makeRequest(overrides: Record<string, unknown> = {}): HttpRequest {
   return {
     id: "msg-1",
     createdAt: "2026-01-01T00:00:00Z",
-    imported: false,
     stage: "Request",
     fetchRequestId: "req-1",
     url: "https://example.com/",
@@ -57,7 +56,6 @@ describe("isHttpMessage", () => {
   const validHttpRequest = {
     id: "msg-123",
     createdAt: "2026-01-01T00:00:00Z",
-    imported: false,
     fetchRequestId: "req-123",
     headers: [{ name: "Content-Type", value: "text/html" }],
     url: "https://example.com/",
@@ -69,7 +67,6 @@ describe("isHttpMessage", () => {
   const validHttpResponse = {
     id: "msg-124",
     createdAt: "2026-01-01T00:00:00Z",
-    imported: false,
     fetchRequestId: "req-123",
     headers: [{ name: "Content-Type", value: "text/html" }],
     url: "https://example.com/",
@@ -180,7 +177,6 @@ describe("newHttpRequest", () => {
     const httpRequest = newHttpRequest(requestPausedEvent);
 
     expect(httpRequest).toMatchObject({
-      imported: false,
       stage: "Request",
       fetchRequestId: "req-1",
       url: "https://sp.example.com/SAML2/ACS",
@@ -267,7 +263,6 @@ describe("newHttpResponse", () => {
     );
 
     expect(httpResponse).toMatchObject({
-      imported: false,
       stage: "Response",
       fetchRequestId: "req-1",
       statusCode: 200,

--- a/src/common/models/http-message.ts
+++ b/src/common/models/http-message.ts
@@ -18,7 +18,6 @@ export function isHttpMessage(u: unknown): u is HttpMessage {
 type HttpMessageBase = {
   id: string;
   createdAt: string;
-  imported: boolean;
   fetchRequestId: Protocol.Fetch.RequestId;
   url: string;
   method: string;
@@ -31,7 +30,6 @@ function isHttpMessageBase(u: unknown): u is HttpMessageBase {
     isObject(u) &&
     typeof u.id === "string" &&
     typeof u.createdAt === "string" &&
-    typeof u.imported === "boolean" &&
     typeof u.fetchRequestId === "string" &&
     typeof u.url === "string" &&
     typeof u.method === "string" &&
@@ -78,7 +76,6 @@ export function newHttpRequest(requestPausedEvent: Protocol.Fetch.RequestPausedE
   return {
     id: uuidv7(),
     createdAt: new Date().toISOString(),
-    imported: false,
     stage: "Request",
     fetchRequestId: requestPausedEvent.requestId,
     url: requestPausedEvent.request.url,
@@ -106,7 +103,6 @@ export function newHttpResponse(
   return {
     id: uuidv7(),
     createdAt: new Date().toISOString(),
-    imported: false,
     stage: "Response",
     fetchRequestId: requestPausedEvent.requestId,
     url: requestPausedEvent.request.url,

--- a/src/common/models/saml-trace.test.ts
+++ b/src/common/models/saml-trace.test.ts
@@ -16,7 +16,6 @@ describe("isSamlTrace", () => {
       observedAt: "2026-01-01T00:00:00Z",
       serverHostname: "sp.example.com",
       sessionId: "abc123",
-      imported: false,
       action: "test action",
       step: 2,
       type: "IncomingAuthnRequest",
@@ -76,10 +75,6 @@ describe("isSamlTrace", () => {
     expect(isSamlTrace({ ...makeTraceFields(), sessionId: 123 })).toBe(false);
   });
 
-  it("returns false when imported is not a boolean", () => {
-    expect(isSamlTrace({ ...makeTraceFields(), imported: "false" })).toBe(false);
-  });
-
   it("returns false when optional samlStatusCode is not a string", () => {
     expect(isSamlTrace({ ...makeTraceFields(), samlStatusCode: 200 })).toBe(false);
   });
@@ -93,7 +88,6 @@ describe("newSamlTrace", () => {
     return {
       id: "msg-1",
       createdAt: "2026-01-01T00:00:00Z",
-      imported: false,
       stage: "Request",
       fetchRequestId: "req-1",
       headers: [],
@@ -108,7 +102,6 @@ describe("newSamlTrace", () => {
     return {
       id: "msg-1",
       createdAt: "2026-01-01T00:00:00Z",
-      imported: false,
       stage: "Response",
       fetchRequestId: "req-1",
       headers: [{ name: "Date", value: DATE_HEADER_VALUE }],
@@ -132,7 +125,6 @@ describe("newSamlTrace", () => {
       observedAt: "2026-01-01T00:00:00Z",
       serverHostname: "sp.example.com",
       sessionId: "authn-req-1",
-      imported: false,
       step: 1,
       type: "UnauthenticatedResourceRequest",
       action: "User Agent requests a secured resource at Service Provider",
@@ -151,7 +143,6 @@ describe("newSamlTrace", () => {
       observedAt: "2026-01-01T00:00:00Z",
       serverHostname: "sp.example.com",
       sessionId: "authn-req-1",
-      imported: false,
       step: 2,
       type: "IncomingAuthnRequest",
       action: "Service Provider issues SAML AuthnRequest",
@@ -231,14 +222,6 @@ describe("newSamlTrace", () => {
       type: "AuthenticatedResourceResponse",
       action: "Service Provider returns the requested resource",
     });
-  });
-
-  it("takes the imported flag from the HTTP message", () => {
-    const response = makeResponse({ imported: true });
-
-    const result = newSamlTrace("flow-1", { step: 2, correlationKey: "authn-req-1" }, response);
-
-    expect(result).toMatchObject({ imported: true });
   });
 
   it("returns Error when the message URL is invalid", () => {

--- a/src/common/models/saml-trace.ts
+++ b/src/common/models/saml-trace.ts
@@ -24,7 +24,6 @@ type SamlTraceBase = {
   observedAt: string;
   serverHostname: string;
   sessionId: string;
-  imported: boolean;
   action: string;
 };
 
@@ -75,7 +74,6 @@ export function isSamlTrace(u: unknown): u is SamlTrace {
     typeof u.observedAt === "string" &&
     typeof u.serverHostname === "string" &&
     typeof u.sessionId === "string" &&
-    typeof u.imported === "boolean" &&
     (!("samlStatusCode" in u) || typeof u.samlStatusCode === "string")
   );
 }
@@ -97,7 +95,6 @@ export function newSamlTrace(
     observedAt: httpMessage.createdAt,
     serverHostname: hostname,
     sessionId: detection.correlationKey,
-    imported: httpMessage.imported,
   };
 
   switch (detection.step) {

--- a/src/common/services/flow-query.test.ts
+++ b/src/common/services/flow-query.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @copyright Internet Initiative Japan Inc. All rights reserved.
+ * @license BSD-3-Clause
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type HttpMessage } from "@/common/models/http-message.ts";
+import { type SamlTrace } from "@/common/models/saml-trace.ts";
+import { retrieveHttpMessages } from "@/common/services/http-store.ts";
+import { findSamlTraces } from "@/common/services/saml-store.ts";
+import { findHttpMessagesOfFlow } from "./flow-query.ts";
+
+vi.mock("@/common/services/http-store.ts", () => ({
+  retrieveHttpMessages: vi.fn(),
+}));
+
+vi.mock("@/common/services/saml-store.ts", () => ({
+  findSamlTraces: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+//
+// Helpers
+//
+
+function makeSamlTrace(httpMessageId: string, sessionId = "corr-1"): SamlTrace {
+  return { httpMessageId, sessionId } as SamlTrace;
+}
+
+function makeRequest(id: string): HttpMessage {
+  return { id, stage: "Request" } as HttpMessage;
+}
+
+function makeResponse(id: string, pairedHttpRequestId: string): HttpMessage {
+  return { id, stage: "Response", pairedHttpRequestId } as HttpMessage;
+}
+
+//
+// Tests
+//
+
+describe("findHttpMessagesOfFlow", () => {
+  it("returns the HTTP messages referenced by the traces of the flow", async () => {
+    const referenced = makeRequest("msg-1");
+    const unreferenced = makeRequest("msg-2");
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-1")]);
+    vi.mocked(retrieveHttpMessages).mockResolvedValue([referenced, unreferenced]);
+
+    const result = await findHttpMessagesOfFlow(1, "corr-1");
+
+    expect(findSamlTraces).toHaveBeenCalledWith(1);
+    expect(retrieveHttpMessages).toHaveBeenCalledWith(1, "corr-1");
+    expect(result).toEqual([referenced]);
+  });
+
+  it("includes the paired request of a referenced response", async () => {
+    const pairedRequest = makeRequest("msg-1");
+    const response = makeResponse("msg-2", "msg-1");
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-2")]);
+    vi.mocked(retrieveHttpMessages).mockResolvedValue([pairedRequest, response]);
+
+    const result = await findHttpMessagesOfFlow(1, "corr-1");
+
+    expect(result).toEqual([pairedRequest, response]);
+  });
+
+  it("ignores the traces of other flows", async () => {
+    const httpMessage = makeRequest("msg-1");
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-1", "corr-2")]);
+    vi.mocked(retrieveHttpMessages).mockResolvedValue([httpMessage]);
+
+    const result = await findHttpMessagesOfFlow(1, "corr-1");
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns an error when the traces cannot be found", async () => {
+    const error = new Error("saml store error");
+    vi.mocked(findSamlTraces).mockResolvedValue(error);
+
+    expect(await findHttpMessagesOfFlow(1, "corr-1")).toBe(error);
+    expect(retrieveHttpMessages).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the HTTP messages cannot be retrieved", async () => {
+    const error = new Error("http store error");
+    vi.mocked(findSamlTraces).mockResolvedValue([]);
+    vi.mocked(retrieveHttpMessages).mockResolvedValue(error);
+
+    expect(await findHttpMessagesOfFlow(1, "corr-1")).toBe(error);
+  });
+});

--- a/src/common/services/flow-query.ts
+++ b/src/common/services/flow-query.ts
@@ -1,0 +1,34 @@
+/**
+ * @copyright Internet Initiative Japan Inc. All rights reserved.
+ * @license BSD-3-Clause
+ */
+
+import { type HttpMessage } from "@/common/models/http-message.ts";
+import { retrieveHttpMessages } from "@/common/services/http-store.ts";
+import { findSamlTraces } from "@/common/services/saml-store.ts";
+
+export async function findHttpMessagesOfFlow(
+  tabId: number,
+  sessionId: string,
+): Promise<HttpMessage[] | Error> {
+  const tabSamlTraces = await findSamlTraces(tabId);
+  if (tabSamlTraces instanceof Error) {
+    return tabSamlTraces;
+  }
+
+  const httpMessages = await retrieveHttpMessages(tabId, sessionId);
+  if (httpMessages instanceof Error) {
+    return httpMessages;
+  }
+
+  const httpMessageIds = new Set(
+    tabSamlTraces.filter((t) => t.sessionId === sessionId).map((t) => t.httpMessageId),
+  );
+  const pairedHttpRequestIds = new Set(
+    httpMessages.flatMap((m) =>
+      m.stage === "Response" && httpMessageIds.has(m.id) ? [m.pairedHttpRequestId] : [],
+    ),
+  );
+
+  return httpMessages.filter((m) => httpMessageIds.has(m.id) || pairedHttpRequestIds.has(m.id));
+}

--- a/src/common/services/http-store.test.ts
+++ b/src/common/services/http-store.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @copyright Internet Initiative Japan Inc. All rights reserved.
+ * @license BSD-3-Clause
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type HttpMessage } from "@/common/models/http-message.ts";
+import {
+  getSessionStorageItemsByKeyPrefix,
+  removeSessionStorageItems,
+  setSessionStorageItem,
+} from "@/common/utils/chrome-storage.ts";
+import { deleteHttpMessages, retrieveHttpMessages, storeHttpMessage } from "./http-store.ts";
+
+vi.mock("@/common/utils/chrome-storage.ts", () => ({
+  getSessionStorageItemsByKeyPrefix: vi.fn(),
+  removeSessionStorageItems: vi.fn(),
+  setSessionStorageItem: vi.fn(),
+}));
+
+let storage: Record<string, unknown>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  storage = {};
+  vi.mocked(getSessionStorageItemsByKeyPrefix).mockImplementation(async (keyPrefix) =>
+    Object.fromEntries(Object.entries(storage).filter(([k]) => k.startsWith(keyPrefix))),
+  );
+  vi.mocked(removeSessionStorageItems).mockImplementation(async (keys) => {
+    for (const key of keys) {
+      delete storage[key];
+    }
+  });
+  vi.mocked(setSessionStorageItem).mockImplementation(async (key, value) => {
+    storage[key] = value;
+  });
+});
+
+//
+// Helpers
+//
+
+function makeRequest(overrides: Record<string, unknown> = {}): HttpMessage {
+  return {
+    id: "msg-1",
+    createdAt: "2026-01-01T00:00:00Z",
+    fetchRequestId: "req-1",
+    url: "https://sp.example.com/",
+    method: "GET",
+    headers: [],
+    body: undefined,
+    stage: "Request",
+    ...overrides,
+  } as HttpMessage;
+}
+
+//
+// Tests
+//
+
+describe("deleteHttpMessages", () => {
+  it("deletes the stored messages by their keys", async () => {
+    const first = makeRequest({ id: "msg-1", fetchRequestId: "req-1" });
+    const second = makeRequest({ id: "msg-2", fetchRequestId: "req-2" });
+    await storeHttpMessage(first, 1, "corr-1");
+    await storeHttpMessage(second, 1, "corr-1");
+
+    expect(await deleteHttpMessages([first], 1, "corr-1")).toBeUndefined();
+
+    expect(await retrieveHttpMessages(1, "corr-1")).toEqual([second]);
+  });
+
+  it("does not delete messages stored under another session", async () => {
+    const httpMessage = makeRequest();
+    await storeHttpMessage(httpMessage, 1, "corr-1");
+    await storeHttpMessage(httpMessage, 1, "corr-2");
+
+    await deleteHttpMessages([httpMessage], 1, "corr-1");
+
+    expect(await retrieveHttpMessages(1, "corr-1")).toEqual([]);
+    expect(await retrieveHttpMessages(1, "corr-2")).toEqual([httpMessage]);
+  });
+
+  it("returns the error from the storage", async () => {
+    const error = new Error("storage error");
+    vi.mocked(removeSessionStorageItems).mockResolvedValue(error);
+
+    expect(await deleteHttpMessages([makeRequest()], 1, "corr-1")).toBe(error);
+  });
+});

--- a/src/common/services/http-store.ts
+++ b/src/common/services/http-store.ts
@@ -7,7 +7,7 @@ import { type HttpMessage, isHttpMessage } from "@/common/models/http-message.ts
 import { makeStorageKey, makeStorageKeyPrefix } from "@/common/services/storage-key.ts";
 import {
   getSessionStorageItemsByKeyPrefix,
-  removeSessionStorageItemsByKeyPrefix,
+  removeSessionStorageItems,
   setSessionStorageItem,
 } from "@/common/utils/chrome-storage.ts";
 
@@ -64,7 +64,14 @@ export async function retrieveHttpMessages(
     });
 }
 
-export async function purgeHttpMessages(tabId: number, sessionId: string): Promise<void | Error> {
-  const keyPrefix = makeStorageKeyPrefixForHttpMessages(tabId, sessionId);
-  return removeSessionStorageItemsByKeyPrefix(keyPrefix);
+export async function deleteHttpMessages(
+  httpMessages: HttpMessage[],
+  tabId: number,
+  sessionId: string,
+): Promise<void | Error> {
+  const keys = httpMessages.map((m) =>
+    makeStorageKeyForHttpMessage(tabId, sessionId, m.fetchRequestId, m.stage),
+  );
+
+  return removeSessionStorageItems(keys);
 }

--- a/src/common/services/saml-detector.test.ts
+++ b/src/common/services/saml-detector.test.ts
@@ -70,7 +70,6 @@ async function deflateAndBase64Encode(text: string): Promise<string> {
 function makeRequest(overrides: Record<string, unknown> = {}): HttpRequest {
   return {
     createdAt: "2026-01-01T00:00:00Z",
-    imported: false,
     stage: "Request",
     fetchRequestId: "req-1",
     headers: [],
@@ -84,7 +83,6 @@ function makeRequest(overrides: Record<string, unknown> = {}): HttpRequest {
 function makeResponse(overrides: Record<string, unknown> = {}): HttpResponse {
   return {
     createdAt: "2026-01-01T00:00:00Z",
-    imported: false,
     stage: "Response",
     fetchRequestId: "req-1",
     headers: [{ name: "Date", value: DATE_HEADER_VALUE }],

--- a/src/common/services/saml-recorder.test.ts
+++ b/src/common/services/saml-recorder.test.ts
@@ -49,7 +49,6 @@ function makeRequest(): HttpRequest {
   return {
     id: "msg-0",
     createdAt: "2025-12-31T23:59:59Z",
-    imported: false,
     stage: "Request",
     fetchRequestId: "req-1",
     headers: [],
@@ -63,7 +62,6 @@ function makeResponse(): HttpResponse {
   return {
     id: "msg-1",
     createdAt: "2026-01-01T00:00:00Z",
-    imported: false,
     stage: "Response",
     fetchRequestId: "req-1",
     headers: [{ name: "Date", value: "Thu, 01 Jan 2026 00:00:00 GMT" }],

--- a/src/common/services/saml-store.test.ts
+++ b/src/common/services/saml-store.test.ts
@@ -48,7 +48,6 @@ function makeTrace(overrides: Record<string, unknown> = {}): SamlTrace {
     observedAt: "2026-01-01T00:00:00Z",
     serverHostname: "sp.example.com",
     sessionId: "session-1",
-    imported: false,
     action: "test action",
     step: 2,
     type: "IncomingAuthnRequest",

--- a/src/common/services/saml-summarizer.test.ts
+++ b/src/common/services/saml-summarizer.test.ts
@@ -21,7 +21,6 @@ function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
     observedAt: "2026-01-01T00:00:00.000Z",
     serverHostname: "sp.example.com",
     sessionId: "session-1",
-    imported: false,
     action: "test action",
     step: 2,
     type: "IncomingAuthnRequest",
@@ -133,15 +132,6 @@ describe("summarizeSamlSession", () => {
     expect(result.end).toBeUndefined();
   });
 
-  it("sets imported to true if any trace is imported", () => {
-    const result = summarizeSamlSession("session-1", [
-      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest", imported: false }),
-      makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest", imported: true }),
-    ]);
-
-    expect(result).toMatchObject({ imported: true });
-  });
-
   it("assigns the serverHostname to sp or idp by the step", () => {
     const result = summarizeSamlSession("session-1", [
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest", serverHostname: "sp.example.com" }),
@@ -185,7 +175,7 @@ describe("summarizeSamlFlow", () => {
     expect(result).toMatchObject({ sessionId: "corr-1", imported: false });
   });
 
-  it("derives imported from the capture session, not from the traces", () => {
+  it("derives imported from the capture session", () => {
     const captureSession: CaptureSession = {
       id: "cs-1",
       imported: true,
@@ -193,7 +183,7 @@ describe("summarizeSamlFlow", () => {
     };
 
     const result = summarizeSamlFlow(flowEntry, captureSession, [
-      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest", imported: false }),
+      makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
     ]);
 
     expect(result).toMatchObject({ imported: true });

--- a/src/common/services/saml-summarizer.test.ts
+++ b/src/common/services/saml-summarizer.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import { type CaptureSession } from "@/common/models/capture-session.ts";
 import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
-import { summarizeSamlFlow, summarizeSamlSession } from "./saml-summarizer.ts";
+import { summarizeSamlFlow } from "./saml-summarizer.ts";
 
 //
 // Helpers
@@ -38,13 +38,26 @@ function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
   return base as SamlTrace;
 }
 
+const flowEntry: FlowEntry = {
+  id: "flow-1",
+  captureSessionId: "cs-1",
+  protocol: "saml",
+  correlationKey: "corr-1",
+};
+
+const captureSession: CaptureSession = {
+  id: "cs-1",
+  imported: false,
+  startedAt: "2026-01-01T00:00:00Z",
+};
+
 //
 // Tests
 //
 
-describe("summarizeSamlSession", () => {
+describe("summarizeSamlFlow", () => {
   it("builds summary from a single trace", () => {
-    const result = summarizeSamlSession("session-1", [
+    const result = summarizeSamlFlow(flowEntry, captureSession, [
       makeSamlTrace({
         step: 2,
         type: "IncomingAuthnRequest",
@@ -54,7 +67,7 @@ describe("summarizeSamlSession", () => {
 
     expect(result).toMatchObject({
       protocol: "saml",
-      sessionId: "session-1",
+      sessionId: "corr-1",
       imported: false,
       capturing: false,
       start: "2026-01-01T00:00:00.000Z",
@@ -67,7 +80,7 @@ describe("summarizeSamlSession", () => {
   });
 
   it("sets status to in_progress before step 6", () => {
-    const result = summarizeSamlSession("session-1", [
+    const result = summarizeSamlFlow(flowEntry, captureSession, [
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
       makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest" }),
       makeSamlTrace({ step: 4, type: "IncomingResponse" }),
@@ -77,7 +90,7 @@ describe("summarizeSamlSession", () => {
   });
 
   it("sets status to succeeded when a step 6 trace is present", () => {
-    const result = summarizeSamlSession("session-1", [
+    const result = summarizeSamlFlow(flowEntry, captureSession, [
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
       makeSamlTrace({ step: 6, type: "AuthenticatedResourceResponse" }),
     ]);
@@ -86,7 +99,7 @@ describe("summarizeSamlSession", () => {
   });
 
   it("sets status to failed when the samlStatusCode is not Success", () => {
-    const result = summarizeSamlSession("session-1", [
+    const result = summarizeSamlFlow(flowEntry, captureSession, [
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
       makeSamlTrace({
         step: 4,
@@ -100,7 +113,7 @@ describe("summarizeSamlSession", () => {
   });
 
   it("sets start and end from the observedAt", () => {
-    const result = summarizeSamlSession("session-1", [
+    const result = summarizeSamlFlow(flowEntry, captureSession, [
       makeSamlTrace({
         step: 2,
         type: "IncomingAuthnRequest",
@@ -120,7 +133,7 @@ describe("summarizeSamlSession", () => {
   });
 
   it("does not set end when status is in_progress", () => {
-    const result = summarizeSamlSession("session-1", [
+    const result = summarizeSamlFlow(flowEntry, captureSession, [
       makeSamlTrace({
         step: 2,
         type: "IncomingAuthnRequest",
@@ -133,7 +146,7 @@ describe("summarizeSamlSession", () => {
   });
 
   it("assigns the serverHostname to sp or idp by the step", () => {
-    const result = summarizeSamlSession("session-1", [
+    const result = summarizeSamlFlow(flowEntry, captureSession, [
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest", serverHostname: "sp.example.com" }),
       makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest", serverHostname: "idp.example.org" }),
       makeSamlTrace({ step: 5, type: "OutgoingResponse", serverHostname: "second-sp.com" }),
@@ -143,7 +156,7 @@ describe("summarizeSamlSession", () => {
   });
 
   it("sets action to the last trace's action", () => {
-    const result = summarizeSamlSession("session-1", [
+    const result = summarizeSamlFlow(flowEntry, captureSession, [
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest", action: "first action" }),
       makeSamlTrace({ step: 3, type: "OutgoingAuthnRequest", action: "second action" }),
       makeSamlTrace({ step: 4, type: "IncomingResponse", action: "third action" }),
@@ -151,23 +164,8 @@ describe("summarizeSamlSession", () => {
 
     expect(result).toMatchObject({ action: "third action" });
   });
-});
-
-describe("summarizeSamlFlow", () => {
-  const flowEntry: FlowEntry = {
-    id: "flow-1",
-    captureSessionId: "cs-1",
-    protocol: "saml",
-    correlationKey: "corr-1",
-  };
 
   it("uses the correlation key of the flow as the session ID", () => {
-    const captureSession: CaptureSession = {
-      id: "cs-1",
-      imported: false,
-      startedAt: "2026-01-01T00:00:00Z",
-    };
-
     const result = summarizeSamlFlow(flowEntry, captureSession, [
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
     ]);
@@ -176,13 +174,13 @@ describe("summarizeSamlFlow", () => {
   });
 
   it("derives imported from the capture session", () => {
-    const captureSession: CaptureSession = {
+    const importedSession: CaptureSession = {
       id: "cs-1",
       imported: true,
       importedAt: "2026-01-01T00:00:00Z",
     };
 
-    const result = summarizeSamlFlow(flowEntry, captureSession, [
+    const result = summarizeSamlFlow(flowEntry, importedSession, [
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
     ]);
 

--- a/src/common/services/saml-summarizer.ts
+++ b/src/common/services/saml-summarizer.ts
@@ -13,19 +13,11 @@ export function summarizeSamlFlow(
   captureSession: CaptureSession,
   samlTraces: SamlTrace[],
 ): SessionSummary {
-  const summary = summarizeSamlSession(flowEntry.correlationKey, samlTraces);
-  return {
-    ...summary,
-    imported: captureSession.imported,
-  };
-}
-
-export function summarizeSamlSession(sessionId: string, samlTraces: SamlTrace[]): SessionSummary {
   return samlTraces.reduce(updateSamlSessionSummary, {
     protocol: "saml",
-    imported: false,
+    imported: captureSession.imported,
     capturing: false,
-    sessionId,
+    sessionId: flowEntry.correlationKey,
     warning: [],
   });
 }

--- a/src/common/services/saml-summarizer.ts
+++ b/src/common/services/saml-summarizer.ts
@@ -55,7 +55,6 @@ function updateSamlSessionSummary(summary: SessionSummary, samlTrace: SamlTrace)
 
   return {
     ...summary,
-    imported: summary.imported || samlTrace.imported,
     start: summary.start ?? samlTrace.observedAt,
     end: summary.end ?? (status !== "in_progress" ? samlTrace.observedAt : undefined),
     sp: summary.sp ?? (role === "sp" ? samlTrace.serverHostname : undefined),

--- a/src/common/services/session-archiver.test.ts
+++ b/src/common/services/session-archiver.test.ts
@@ -71,7 +71,6 @@ describe("loadSessionArchive", () => {
   it("returns session IDs on success", async () => {
     const httpMessage = {
       stage: "Request",
-      imported: false,
       url: "https://idp.example.org/sso",
       method: "GET",
     } as unknown as HttpMessage;
@@ -86,31 +85,25 @@ describe("loadSessionArchive", () => {
     const result = await loadSessionArchive(1, "har-string");
 
     expect(result).toEqual(["session-1"]);
-    expect(storeHttpMessage).toHaveBeenCalledWith(
-      { ...httpMessage, imported: true },
-      1,
-      "session-1",
-    );
+    expect(storeHttpMessage).toHaveBeenCalledWith(httpMessage, 1, "session-1");
     expect(recordSamlTrace).toHaveBeenCalledWith(
       expect.any(String),
       1,
       { step: 3, correlationKey: "session-1" },
-      { ...httpMessage, imported: true },
+      httpMessage,
       undefined,
     );
   });
 
-  it("stores the paired request of a response as an imported message", async () => {
+  it("stores the paired request of a response ", async () => {
     const pairedRequest = {
       id: "msg-1",
       stage: "Request",
-      imported: false,
       url: "https://sp.example.com/resource",
     } as unknown as HttpMessage;
     const httpMessage = {
       id: "msg-2",
       stage: "Response",
-      imported: false,
       pairedHttpRequestId: "msg-1",
       url: "https://sp.example.com/acs",
       headers: [],
@@ -128,24 +121,14 @@ describe("loadSessionArchive", () => {
 
     expect(detectSamlStepFromHttpResponse).toHaveBeenCalledWith(httpMessage, pairedRequest);
     expect(storeHttpMessage).toHaveBeenCalledTimes(2);
-    expect(storeHttpMessage).toHaveBeenNthCalledWith(
-      1,
-      { ...pairedRequest, imported: true },
-      1,
-      "session-1",
-    );
-    expect(storeHttpMessage).toHaveBeenNthCalledWith(
-      2,
-      { ...httpMessage, imported: true },
-      1,
-      "session-1",
-    );
+    expect(storeHttpMessage).toHaveBeenNthCalledWith(1, pairedRequest, 1, "session-1");
+    expect(storeHttpMessage).toHaveBeenNthCalledWith(2, httpMessage, 1, "session-1");
     expect(recordSamlTrace).toHaveBeenCalledExactlyOnceWith(
       expect.any(String),
       1,
       { step: 6, correlationKey: "session-1" },
-      { ...httpMessage, imported: true },
-      { ...pairedRequest, imported: true },
+      httpMessage,
+      pairedRequest,
     );
   });
 
@@ -154,7 +137,6 @@ describe("loadSessionArchive", () => {
     const httpMessage = {
       id: "msg-2",
       stage: "Response",
-      imported: false,
       pairedHttpRequestId: "msg-1",
     } as unknown as HttpMessage;
     vi.mocked(toHttpMessages).mockReturnValue([httpMessage]);
@@ -170,7 +152,6 @@ describe("loadSessionArchive", () => {
   it("records the traces under the imported capture session", async () => {
     const httpMessage = {
       stage: "Request",
-      imported: false,
       url: "https://idp.example.org/sso",
       method: "GET",
     } as unknown as HttpMessage;
@@ -191,7 +172,6 @@ describe("loadSessionArchive", () => {
   it("aborts when a trace cannot be recorded", async () => {
     const httpMessage = {
       stage: "Request",
-      imported: false,
       url: "https://idp.example.org/sso",
       method: "GET",
     } as unknown as HttpMessage;
@@ -237,7 +217,7 @@ describe("loadSessionArchive", () => {
   });
 
   it("returns empty array when no SAML steps are detected", async () => {
-    const httpMessage = { stage: "Request", imported: false } as unknown as HttpMessage;
+    const httpMessage = { stage: "Request" } as unknown as HttpMessage;
     vi.mocked(toHttpMessages).mockReturnValue([httpMessage]);
     vi.mocked(detectSamlStepFromHttpRequest).mockResolvedValue(undefined);
 
@@ -248,8 +228,8 @@ describe("loadSessionArchive", () => {
 
   it("returns deduplicated session IDs", async () => {
     const httpMessages = [
-      { stage: "Request", imported: false, url: "https://idp.example.org/sso" },
-      { stage: "Request", imported: false, url: "https://idp.example.org/sso" },
+      { stage: "Request", url: "https://idp.example.org/sso" },
+      { stage: "Request", url: "https://idp.example.org/sso" },
     ] as unknown as HttpMessage[];
     vi.mocked(toHttpMessages).mockReturnValue(httpMessages);
     vi.mocked(detectSamlStepFromHttpRequest).mockResolvedValue({

--- a/src/common/services/session-archiver.test.ts
+++ b/src/common/services/session-archiver.test.ts
@@ -7,7 +7,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { newHar, toHttpMessages } from "@/common/models/http-archive.ts";
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { saveEventRecord } from "@/common/services/event-store.ts";
-import { retrieveHttpMessages, storeHttpMessage } from "@/common/services/http-store.ts";
+import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import { storeHttpMessage } from "@/common/services/http-store.ts";
 import {
   detectSamlStepFromHttpRequest,
   detectSamlStepFromHttpResponse,
@@ -24,8 +25,11 @@ vi.mock("@/common/services/event-store.ts", () => ({
   saveEventRecord: vi.fn(),
 }));
 
+vi.mock("@/common/services/flow-query.ts", () => ({
+  findHttpMessagesOfFlow: vi.fn(),
+}));
+
 vi.mock("@/common/services/http-store.ts", () => ({
-  retrieveHttpMessages: vi.fn(),
   storeHttpMessage: vi.fn(),
 }));
 
@@ -46,18 +50,18 @@ beforeEach(() => {
 describe("dumpSessionArchive", () => {
   it("returns HAR string on success", async () => {
     const httpMessages = [{} as HttpMessage];
-    vi.mocked(retrieveHttpMessages).mockResolvedValue(httpMessages);
+    vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(httpMessages);
     vi.mocked(newHar).mockReturnValue('{"log":{}}');
 
     const result = await dumpSessionArchive(1, "session-1");
 
-    expect(retrieveHttpMessages).toHaveBeenCalledWith(1, "session-1");
+    expect(findHttpMessagesOfFlow).toHaveBeenCalledWith(1, "session-1");
     expect(newHar).toHaveBeenCalledWith(httpMessages);
     expect(result).toBe('{"log":{}}');
   });
 
-  it("returns Error when retrieveHttpMessages fails", async () => {
-    vi.mocked(retrieveHttpMessages).mockResolvedValue(new Error("storage error"));
+  it("returns Error when findHttpMessagesOfFlow fails", async () => {
+    vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(new Error("storage error"));
 
     const result = await dumpSessionArchive(1, "session-1");
 

--- a/src/common/services/session-archiver.ts
+++ b/src/common/services/session-archiver.ts
@@ -12,7 +12,8 @@ import {
 } from "@/common/models/http-message.ts";
 import { type SamlDetection } from "@/common/models/saml-detection.ts";
 import { saveEventRecord } from "@/common/services/event-store.ts";
-import { retrieveHttpMessages, storeHttpMessage } from "@/common/services/http-store.ts";
+import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import { storeHttpMessage } from "@/common/services/http-store.ts";
 import {
   detectSamlStepFromHttpRequest,
   detectSamlStepFromHttpResponse,
@@ -30,7 +31,7 @@ export async function dumpSessionArchive(
   tabId: number,
   sessionId: string,
 ): Promise<string | Error> {
-  const httpMessages = await retrieveHttpMessages(tabId, sessionId);
+  const httpMessages = await findHttpMessagesOfFlow(tabId, sessionId);
   if (httpMessages instanceof Error) {
     return httpMessages;
   }

--- a/src/common/services/session-archiver.ts
+++ b/src/common/services/session-archiver.ts
@@ -41,7 +41,6 @@ export async function dumpSessionArchive(
 /**
  * Import session data from an HTTP Archive (HAR) JSON string.
  *
- * Imported sessions are marked with the `imported` flag.
  * A single archive may contain multiple sessions.
  *
  * @param tabId - The tab ID to associate with imported sessions
@@ -82,22 +81,9 @@ export async function loadSessionArchive(tabId: number, har: string): Promise<st
       continue;
     }
 
-    const importedHttpMessage = {
-      ...httpMessage,
-      imported: true,
-    };
-
-    const importedPairedHttpRequest =
-      pairedHttpRequest === undefined
-        ? undefined
-        : {
-            ...pairedHttpRequest,
-            imported: true,
-          };
-
-    if (importedPairedHttpRequest !== undefined) {
+    if (pairedHttpRequest !== undefined) {
       const httpStoreError = await storeHttpMessage(
-        importedPairedHttpRequest,
+        pairedHttpRequest,
         tabId,
         detection.correlationKey,
       );
@@ -106,11 +92,7 @@ export async function loadSessionArchive(tabId: number, har: string): Promise<st
       }
     }
 
-    const httpStoreError = await storeHttpMessage(
-      importedHttpMessage,
-      tabId,
-      detection.correlationKey,
-    );
+    const httpStoreError = await storeHttpMessage(httpMessage, tabId, detection.correlationKey);
     if (httpStoreError) {
       return httpStoreError;
     }
@@ -119,8 +101,8 @@ export async function loadSessionArchive(tabId: number, har: string): Promise<st
       archiveImportedRecord.id,
       tabId,
       detection,
-      importedHttpMessage,
-      importedPairedHttpRequest,
+      httpMessage,
+      pairedHttpRequest,
     );
     if (recordError) {
       return recordError;

--- a/src/common/services/session-manager.test.ts
+++ b/src/common/services/session-manager.test.ts
@@ -58,7 +58,6 @@ function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
     observedAt: "2026-01-01T00:00:00.000Z",
     serverHostname: "sp.example.com",
     sessionId: "corr-1",
-    imported: false,
     action: "test action",
     step: 2,
     type: "IncomingAuthnRequest",
@@ -118,7 +117,7 @@ describe("getSessionSummaries", () => {
   });
 
   it("derives imported from the capture session", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({ imported: false })]);
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
     vi.mocked(getCaptureSession).mockResolvedValue(
       makeCaptureSession({ imported: true, importedAt: "2026-01-01T00:00:00Z" }),
     );

--- a/src/common/services/session-manager.test.ts
+++ b/src/common/services/session-manager.test.ts
@@ -6,10 +6,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type CaptureSession } from "@/common/models/capture-session.ts";
 import { type FlowEntry } from "@/common/models/flow-entry.ts";
+import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { getCaptureSession } from "@/common/services/capture-query.ts";
 import { findFlowEntryById } from "@/common/services/flow-store.ts";
-import { purgeHttpMessages } from "@/common/services/http-store.ts";
+import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import { deleteHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTraces, findSamlTraces } from "@/common/services/saml-store.ts";
 import { isAttached } from "@/common/utils/chrome-debugger.ts";
 import { deleteSession, getSessionSummaries } from "./session-manager.ts";
@@ -22,8 +24,12 @@ vi.mock("@/common/services/flow-store.ts", () => ({
   findFlowEntryById: vi.fn(),
 }));
 
+vi.mock("@/common/services/flow-query.ts", () => ({
+  findHttpMessagesOfFlow: vi.fn(),
+}));
+
 vi.mock("@/common/services/http-store.ts", () => ({
-  purgeHttpMessages: vi.fn(),
+  deleteHttpMessages: vi.fn(),
 }));
 
 vi.mock("@/common/services/saml-store.ts", () => ({
@@ -42,8 +48,9 @@ beforeEach(() => {
   vi.mocked(getCaptureSession).mockResolvedValue(undefined);
   vi.mocked(findFlowEntryById).mockResolvedValue(undefined);
   vi.mocked(isAttached).mockResolvedValue(false);
+  vi.mocked(findHttpMessagesOfFlow).mockResolvedValue([]);
   vi.mocked(deleteSamlTraces).mockResolvedValue(undefined);
-  vi.mocked(purgeHttpMessages).mockResolvedValue(undefined);
+  vi.mocked(deleteHttpMessages).mockResolvedValue(undefined);
 });
 
 //
@@ -205,10 +212,26 @@ describe("getSessionSummaries", () => {
 });
 
 describe("deleteSession", () => {
-  it("deletes the traces and the HTTP messages", async () => {
+  it("deletes the traces and then the HTTP messages of the flow", async () => {
+    const httpMessages = [{ id: "msg-1" } as HttpMessage];
+    vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(httpMessages);
+
     expect(await deleteSession(1, "corr-1")).toBeUndefined();
+    expect(findHttpMessagesOfFlow).toHaveBeenCalledWith(1, "corr-1");
     expect(deleteSamlTraces).toHaveBeenCalledWith(1, "corr-1");
-    expect(purgeHttpMessages).toHaveBeenCalledWith(1, "corr-1");
+    expect(deleteHttpMessages).toHaveBeenCalledWith(httpMessages, 1, "corr-1");
+    expect(vi.mocked(deleteSamlTraces).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(deleteHttpMessages).mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("returns an error when the HTTP messages cannot be found", async () => {
+    const error = new Error("query error");
+    vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(error);
+
+    expect(await deleteSession(1, "corr-1")).toBe(error);
+    expect(deleteSamlTraces).not.toHaveBeenCalled();
+    expect(deleteHttpMessages).not.toHaveBeenCalled();
   });
 
   it("returns an error when the trace deletion fails", async () => {
@@ -216,12 +239,12 @@ describe("deleteSession", () => {
     vi.mocked(deleteSamlTraces).mockResolvedValue(error);
 
     expect(await deleteSession(1, "corr-1")).toBe(error);
-    expect(purgeHttpMessages).not.toHaveBeenCalled();
+    expect(deleteHttpMessages).not.toHaveBeenCalled();
   });
 
-  it("ignores a failure of the HTTP message purge", async () => {
+  it("ignores a failure of the HTTP message deletion", async () => {
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.mocked(purgeHttpMessages).mockResolvedValue(new Error("http purge error"));
+    vi.mocked(deleteHttpMessages).mockResolvedValue(new Error("http delete error"));
 
     expect(await deleteSession(1, "corr-1")).toBeUndefined();
     expect(consoleWarn).toHaveBeenCalledOnce();

--- a/src/common/services/session-manager.ts
+++ b/src/common/services/session-manager.ts
@@ -8,7 +8,8 @@ import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { type SessionSummary, debugSessionSummary } from "@/common/models/session-summary.ts";
 import { getCaptureSession } from "@/common/services/capture-query.ts";
 import { findFlowEntryById } from "@/common/services/flow-store.ts";
-import { purgeHttpMessages } from "@/common/services/http-store.ts";
+import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import { deleteHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTraces, findSamlTraces } from "@/common/services/saml-store.ts";
 import { summarizeSamlFlow } from "@/common/services/saml-summarizer.ts";
 import { isAttached } from "@/common/utils/chrome-debugger.ts";
@@ -94,14 +95,19 @@ function isOngoing(captureSession: CaptureSession): boolean {
  * @returns void on success, or an Error
  */
 export async function deleteSession(tabId: number, sessionId: string): Promise<void | Error> {
+  const httpMessages = await findHttpMessagesOfFlow(tabId, sessionId);
+  if (httpMessages instanceof Error) {
+    return httpMessages;
+  }
+
   const samlDeleteError = await deleteSamlTraces(tabId, sessionId);
   if (samlDeleteError) {
     return samlDeleteError;
   }
 
-  const httpPurgeError = await purgeHttpMessages(tabId, sessionId);
-  if (httpPurgeError) {
-    // HTTP messages don't need to be purged, so we ignore failures
-    console.warn("Failed to purge HTTP messages:", httpPurgeError);
+  const httpDeleteError = await deleteHttpMessages(httpMessages, tabId, sessionId);
+  if (httpDeleteError) {
+    // HTTP messages don't need to be deleted, so we ignore failures
+    console.warn("Failed to delete HTTP messages:", httpDeleteError);
   }
 }

--- a/src/report-page/app-builders.test.ts
+++ b/src/report-page/app-builders.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @copyright Internet Initiative Japan Inc. All rights reserved.
+ * @license BSD-3-Clause
+ */
+
+import { Base64 } from "js-base64";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type HttpMessage } from "@/common/models/http-message.ts";
+import { type SamlTrace } from "@/common/models/saml-trace.ts";
+import {
+  buildHttpMessageRecord,
+  getSamlAuthnRequestXml,
+  getSamlResponseXml,
+} from "./app-builders.ts";
+
+//
+// Helpers
+//
+
+function makeHttpMessage(id: string): HttpMessage {
+  return {
+    id,
+    createdAt: "2026-01-01T00:00:00Z",
+    imported: false,
+    stage: "Request",
+    fetchRequestId: "req-1",
+    url: "https://sp.example.com/",
+    method: "GET",
+    headers: [],
+    body: "",
+  };
+}
+
+function makePostRequest(id: string, body: string): HttpMessage {
+  return {
+    ...makeHttpMessage(id),
+    method: "POST",
+    headers: [{ name: "Content-Type", value: "application/x-www-form-urlencoded" }],
+    body,
+  };
+}
+
+function makeSamlTrace(id: string, step: SamlTrace["step"], httpMessageId: string): SamlTrace {
+  return {
+    id,
+    flowId: "flow-1",
+    httpMessageId,
+    observedAt: "2026-01-01T00:00:00Z",
+    serverHostname: "sp.example.com",
+    sessionId: "corr-1",
+    imported: false,
+    action: "test action",
+    step,
+    type: "UnauthenticatedResourceRequest",
+  } as SamlTrace;
+}
+
+//
+// Tests
+//
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(console, "info").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+describe("buildHttpMessageRecord", () => {
+  it("maps each SAML step to the HTTP message referenced by its trace", () => {
+    const msg1 = makeHttpMessage("msg-1");
+    const msg2 = makeHttpMessage("msg-2");
+
+    const result = buildHttpMessageRecord(
+      [makeSamlTrace("trace-1", 1, "msg-1"), makeSamlTrace("trace-2", 2, "msg-2")],
+      [msg1, msg2],
+    );
+
+    expect(result).toEqual({ 1: msg1, 2: msg2 });
+  });
+
+  it("keeps the last trace when the same step appears more than once", () => {
+    const msg1 = makeHttpMessage("msg-1");
+    const msg2 = makeHttpMessage("msg-2");
+
+    const result = buildHttpMessageRecord(
+      [makeSamlTrace("trace-1", 4, "msg-1"), makeSamlTrace("trace-2", 4, "msg-2")],
+      [msg1, msg2],
+    );
+
+    expect(result).toEqual({ 4: msg2 });
+    expect(console.info).toHaveBeenCalledOnce();
+  });
+
+  it("skips a trace whose HTTP message is missing", () => {
+    const msg2 = makeHttpMessage("msg-2");
+
+    const result = buildHttpMessageRecord(
+      [makeSamlTrace("trace-1", 1, "msg-1"), makeSamlTrace("trace-2", 2, "msg-2")],
+      [msg2],
+    );
+
+    expect(result).toEqual({ 2: msg2 });
+    expect(console.warn).toHaveBeenCalledOnce();
+  });
+
+  it("returns an empty record when there are no traces", () => {
+    expect(buildHttpMessageRecord([], [makeHttpMessage("msg-1")])).toEqual({});
+  });
+});
+
+describe("getSamlAuthnRequestXml", () => {
+  const xml2 = '<samlp:AuthnRequest ID="from-step-2"/>';
+  const xml3 = '<samlp:AuthnRequest ID="from-step-3"/>';
+  const step2 = makePostRequest("msg-2", `SAMLRequest=${encodeURIComponent(Base64.encode(xml2))}`);
+  const step3 = makePostRequest("msg-3", `SAMLRequest=${encodeURIComponent(Base64.encode(xml3))}`);
+
+  it("extracts from step 2 when present", async () => {
+    expect(await getSamlAuthnRequestXml({ 2: step2, 3: step3 })).toBe(xml2);
+  });
+
+  it("falls back to step 3 when step 2 is missing", async () => {
+    expect(await getSamlAuthnRequestXml({ 3: step3 })).toBe(xml3);
+  });
+
+  it("returns undefined when neither step is present", async () => {
+    expect(await getSamlAuthnRequestXml({ 1: makeHttpMessage("msg-1") })).toBeUndefined();
+  });
+});
+
+describe("getSamlResponseXml", () => {
+  const xml4 = '<samlp:Response ID="from-step-4"/>';
+  const xml5 = '<samlp:Response ID="from-step-5"/>';
+  const step4 = makePostRequest("msg-4", `SAMLResponse=${encodeURIComponent(Base64.encode(xml4))}`);
+  const step5 = makePostRequest("msg-5", `SAMLResponse=${encodeURIComponent(Base64.encode(xml5))}`);
+
+  it("extracts from step 4 when present", async () => {
+    expect(await getSamlResponseXml({ 4: step4, 5: step5 })).toBe(xml4);
+  });
+
+  it("falls back to step 5 when step 4 is missing", async () => {
+    expect(await getSamlResponseXml({ 5: step5 })).toBe(xml5);
+  });
+
+  it("returns undefined when neither step is present", async () => {
+    expect(await getSamlResponseXml({ 6: makeHttpMessage("msg-6") })).toBeUndefined();
+  });
+});

--- a/src/report-page/app-builders.test.ts
+++ b/src/report-page/app-builders.test.ts
@@ -21,7 +21,6 @@ function makeHttpMessage(id: string): HttpMessage {
   return {
     id,
     createdAt: "2026-01-01T00:00:00Z",
-    imported: false,
     stage: "Request",
     fetchRequestId: "req-1",
     url: "https://sp.example.com/",
@@ -48,7 +47,6 @@ function makeSamlTrace(id: string, step: SamlTrace["step"], httpMessageId: strin
     observedAt: "2026-01-01T00:00:00Z",
     serverHostname: "sp.example.com",
     sessionId: "corr-1",
-    imported: false,
     action: "test action",
     step,
     type: "UnauthenticatedResourceRequest",

--- a/src/report-page/app-builders.ts
+++ b/src/report-page/app-builders.ts
@@ -1,0 +1,126 @@
+/**
+ * @copyright Internet Initiative Japan Inc. All rights reserved.
+ * @license BSD-3-Clause
+ */
+
+import { type HttpMessage } from "@/common/models/http-message.ts";
+import { type SamlTrace } from "@/common/models/saml-trace.ts";
+import { getCaptureSession } from "@/common/services/capture-query.ts";
+import { findFlowEntryById } from "@/common/services/flow-store.ts";
+import { retrieveHttpMessages } from "@/common/services/http-store.ts";
+import {
+  extractSamlAuthnRequestXml,
+  extractSamlResponseXml,
+} from "@/common/services/saml-detector.ts";
+import { findSamlTraces } from "@/common/services/saml-store.ts";
+import { type FlowData } from "@/report-page/common/types.ts";
+
+export async function loadFlowData(
+  tabId: number,
+  sessionId: string | null,
+): Promise<FlowData | Error> {
+  if (!Number.isSafeInteger(tabId) || tabId <= 0 || sessionId === null) {
+    // In development mode, fall back to sample data
+    if (import.meta.env.MODE === "development") {
+      const { buildSampleFlowData } = await import("@/report-page/dev/sample-flow.ts");
+      return buildSampleFlowData();
+    } else {
+      return new Error(`Invalid URL params: tabId=${tabId}, sessionId=${sessionId}`);
+    }
+  }
+
+  const tabSamlTraces = await findSamlTraces(tabId);
+  if (tabSamlTraces instanceof Error) {
+    return tabSamlTraces;
+  }
+
+  const samlTraces = tabSamlTraces.filter((t) => t.sessionId === sessionId);
+  const firstSamlTrace = samlTraces[0];
+  if (firstSamlTrace === undefined) {
+    return new Error(`No SAML traces: tabId=${tabId}, sessionId=${sessionId}`);
+  }
+
+  const flowEntry = await findFlowEntryById(firstSamlTrace.flowId);
+  if (flowEntry instanceof Error) {
+    return flowEntry;
+  } else if (flowEntry === undefined) {
+    return new Error(`No flow entry: ${firstSamlTrace.flowId}`);
+  }
+
+  const captureSession = await getCaptureSession(flowEntry.captureSessionId);
+  if (captureSession instanceof Error) {
+    return captureSession;
+  } else if (captureSession === undefined) {
+    return new Error(`No capture session: ${flowEntry.captureSessionId}`);
+  }
+
+  const httpMessages = await retrieveHttpMessages(tabId, sessionId);
+  if (httpMessages instanceof Error) {
+    return httpMessages;
+  }
+
+  return { flowEntry, captureSession, samlTraces, httpMessages };
+}
+
+export function buildHttpMessageRecord(
+  samlTraces: SamlTrace[],
+  httpMessages: HttpMessage[],
+): Record<number, HttpMessage> {
+  const httpMessageRecord: Record<number, HttpMessage> = {};
+
+  for (const samlTrace of samlTraces) {
+    if (samlTrace.step in httpMessageRecord) {
+      console.info("Duplicate SAML step, keeping the last one:", {
+        step: samlTrace.step,
+        traceId: samlTrace.id,
+      });
+    }
+
+    const httpMessage = httpMessages.find((m) => m.id === samlTrace.httpMessageId);
+    if (httpMessage === undefined) {
+      console.warn("No HTTP message for the SAML trace:", {
+        step: samlTrace.step,
+        httpMessageId: samlTrace.httpMessageId,
+      });
+      continue;
+    }
+
+    httpMessageRecord[samlTrace.step] = httpMessage;
+  }
+
+  return httpMessageRecord;
+}
+
+export async function getSamlAuthnRequestXml(
+  httpMessageRecord: Record<number, HttpMessage>,
+): Promise<string | undefined> {
+  const httpMessage = httpMessageRecord[2] ?? httpMessageRecord[3];
+  if (httpMessage === undefined) {
+    return undefined;
+  }
+
+  const authnRequestXml = await extractSamlAuthnRequestXml(httpMessage);
+  if (authnRequestXml instanceof Error) {
+    console.warn("Failed to extract SAML AuthnRequest XML:", authnRequestXml);
+    return undefined;
+  }
+
+  return authnRequestXml;
+}
+
+export async function getSamlResponseXml(
+  httpMessageRecord: Record<number, HttpMessage>,
+): Promise<string | undefined> {
+  const httpMessage = httpMessageRecord[4] ?? httpMessageRecord[5];
+  if (httpMessage === undefined) {
+    return undefined;
+  }
+
+  const responseXml = await extractSamlResponseXml(httpMessage);
+  if (responseXml instanceof Error) {
+    console.warn("Failed to extract SAML Response XML:", responseXml);
+    return undefined;
+  }
+
+  return responseXml;
+}

--- a/src/report-page/app-builders.ts
+++ b/src/report-page/app-builders.ts
@@ -6,8 +6,8 @@
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { getCaptureSession } from "@/common/services/capture-query.ts";
+import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
 import { findFlowEntryById } from "@/common/services/flow-store.ts";
-import { retrieveHttpMessages } from "@/common/services/http-store.ts";
 import {
   extractSamlAuthnRequestXml,
   extractSamlResponseXml,
@@ -54,7 +54,7 @@ export async function loadFlowData(
     return new Error(`No capture session: ${flowEntry.captureSessionId}`);
   }
 
-  const httpMessages = await retrieveHttpMessages(tabId, sessionId);
+  const httpMessages = await findHttpMessagesOfFlow(tabId, sessionId);
   if (httpMessages instanceof Error) {
     return httpMessages;
   }

--- a/src/report-page/app.tsx
+++ b/src/report-page/app.tsx
@@ -4,22 +4,15 @@
  */
 
 import { useEffect, useRef, useState } from "react";
-import {
-  type HttpMessage,
-  type HttpRequest,
-  type HttpResponse,
-} from "@/common/models/http-message.ts";
-import { type SamlDetection } from "@/common/models/saml-detection.ts";
-import { type SamlTrace, newSamlTrace } from "@/common/models/saml-trace.ts";
+import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SessionSummary } from "@/common/models/session-summary.ts";
-import { retrieveHttpMessages } from "@/common/services/http-store.ts";
+import { summarizeSamlFlow } from "@/common/services/saml-summarizer.ts";
 import {
-  detectSamlStepFromHttpRequest,
-  detectSamlStepFromHttpResponse,
-  extractSamlAuthnRequestXml,
-  extractSamlResponseXml,
-} from "@/common/services/saml-detector.ts";
-import { summarizeSamlSession } from "@/common/services/saml-summarizer.ts";
+  buildHttpMessageRecord,
+  getSamlAuthnRequestXml,
+  getSamlResponseXml,
+  loadFlowData,
+} from "@/report-page/app-builders.ts";
 import { type ContentSectionId } from "@/report-page/common/types.ts";
 import { Content } from "@/report-page/content/content.tsx";
 import { Sidebar } from "@/report-page/sidebar/sidebar.tsx";
@@ -41,27 +34,22 @@ export function App() {
       const tabId = Number(params.get("tabId"));
       const sessionId = params.get("sessionId");
 
-      const httpMessages = await loadHttpMessages(tabId, sessionId);
-      if (httpMessages instanceof Error) {
-        console.warn("Failed to load HTTP messages:", { error: httpMessages });
+      const flowData = await loadFlowData(tabId, sessionId);
+      if (flowData instanceof Error) {
+        console.warn("Failed to load flow data:", { error: flowData });
         return;
       }
+      const { flowEntry, captureSession, samlTraces, httpMessages } = flowData;
 
-      const httpMessageRecord = await buildHttpMessageRecord(httpMessages);
+      const httpMessageRecord = buildHttpMessageRecord(samlTraces, httpMessages);
       if (Object.keys(httpMessageRecord).length === 0) {
-        console.warn("No SAML steps detected");
+        console.warn("No HTTP messages for the SAML traces");
         return;
       }
 
-      const samlTraces = await buildSamlTraces(httpMessages);
-      if (samlTraces.length === 0) {
-        console.warn("No SAML traces");
-        return;
-      }
-
-      const sessionSummary = summarizeSamlSession(samlTraces[0]!.sessionId, samlTraces);
-      const authnRequestXml = await extractSamlAuthnRequestXmlFromHttpMessages(httpMessages);
-      const responseXml = await extractSamlResponseXmlFromHttpMessages(httpMessages);
+      const sessionSummary = summarizeSamlFlow(flowEntry, captureSession, samlTraces);
+      const authnRequestXml = await getSamlAuthnRequestXml(httpMessageRecord);
+      const responseXml = await getSamlResponseXml(httpMessageRecord);
 
       setSessionData({ httpMessageRecord, sessionSummary, authnRequestXml, responseXml });
     };
@@ -172,160 +160,4 @@ export function App() {
       )}
     </div>
   );
-}
-
-async function loadHttpMessages(
-  tabId: number,
-  sessionId: string | null,
-): Promise<HttpMessage[] | Error> {
-  if (!Number.isSafeInteger(tabId) || tabId <= 0 || sessionId === null) {
-    // In development mode, fall back to sample data
-    if (import.meta.env.MODE === "development") {
-      const { buildSampleHttpMessages } = await import("@/report-page/dev/sample-messages.ts");
-      return buildSampleHttpMessages();
-    } else {
-      return new Error(`Invalid URL params: tabId=${tabId}, sessionId=${sessionId}`);
-    }
-  }
-
-  return retrieveHttpMessages(tabId, sessionId);
-}
-
-async function buildSamlTraces(httpMessages: HttpMessage[]): Promise<SamlTrace[]> {
-  const samlTraces = [];
-
-  for (const httpMessage of httpMessages) {
-    const samlDetection = await detectSamlStep(httpMessage, httpMessages);
-    if (samlDetection instanceof Error) {
-      console.error("Failed to detect SAML flow from HTTP message:", samlDetection);
-      continue;
-    } else if (!samlDetection) {
-      continue;
-    }
-
-    const samlTrace = newSamlTrace(samlDetection.correlationKey, samlDetection, httpMessage);
-    if (samlTrace instanceof Error) {
-      console.error("Failed to build SAML trace from HTTP message:", samlTrace);
-      continue;
-    }
-
-    samlTraces.push(samlTrace);
-  }
-
-  return samlTraces;
-}
-
-async function buildHttpMessageRecord(
-  httpMessages: HttpMessage[],
-): Promise<Record<number, HttpMessage>> {
-  const httpMessageRecord: Record<number, HttpMessage> = {};
-
-  for (const httpMessage of httpMessages) {
-    const samlDetection = await detectSamlStep(httpMessage, httpMessages);
-    if (samlDetection instanceof Error) {
-      console.error("Failed to detect SAML flow from HTTP message:", samlDetection);
-      continue;
-    } else if (!samlDetection) {
-      continue;
-    }
-
-    httpMessageRecord[samlDetection.step] = httpMessage;
-  }
-
-  // Infer step 1 from the message just before step 2
-  if (!(1 in httpMessageRecord) && 2 in httpMessageRecord) {
-    const step2HttpMessage = httpMessageRecord[2];
-    const step2Index = httpMessages.indexOf(step2HttpMessage);
-    if (0 < step2Index) {
-      httpMessageRecord[1] = httpMessages[step2Index - 1]!;
-    } else {
-      console.warn("Could not infer step 1 because no message was found before step 2");
-    }
-  }
-
-  return httpMessageRecord;
-}
-
-async function detectSamlStep(
-  httpMessage: HttpMessage,
-  httpMessages: HttpMessage[],
-): Promise<SamlDetection | undefined | Error> {
-  if (httpMessage.stage === "Request") {
-    return detectSamlStepFromHttpRequest(httpMessage);
-  } else {
-    const pairedHttpRequest = findPairedHttpRequest(httpMessage, httpMessages);
-    if (pairedHttpRequest === undefined) {
-      return new Error(`No paired HTTP request for HTTP response: ${httpMessage.id}`);
-    }
-
-    return detectSamlStepFromHttpResponse(httpMessage, pairedHttpRequest);
-  }
-}
-
-function findPairedHttpRequest(
-  httpResponse: HttpResponse,
-  httpMessages: HttpMessage[],
-): HttpRequest | undefined {
-  const pairedHttpRequest = httpMessages.find((m) => m.id === httpResponse.pairedHttpRequestId);
-  return pairedHttpRequest?.stage === "Request" ? pairedHttpRequest : undefined;
-}
-
-async function extractSamlAuthnRequestXmlFromHttpMessages(
-  httpMessages: HttpMessage[],
-): Promise<string | undefined> {
-  const httpMessage = await (async () => {
-    for (const httpMessage of httpMessages) {
-      const samlDetection = await detectSamlStep(httpMessage, httpMessages);
-      if (samlDetection instanceof Error) {
-        console.error("Failed to detect SAML flow from HTTP message:", samlDetection);
-        continue;
-      } else if (!samlDetection) {
-        continue;
-      } else if (samlDetection.step === 2 || samlDetection.step === 3) {
-        return httpMessage;
-      }
-    }
-    return undefined;
-  })();
-  if (!httpMessage) {
-    return undefined;
-  }
-
-  const authnRequestXml = await extractSamlAuthnRequestXml(httpMessage);
-  if (authnRequestXml instanceof Error) {
-    console.warn("Failed to extract SAML AuthnRequest XML:", authnRequestXml);
-    return undefined;
-  }
-
-  return authnRequestXml;
-}
-
-async function extractSamlResponseXmlFromHttpMessages(
-  httpMessages: HttpMessage[],
-): Promise<string | undefined> {
-  const httpMessage = await (async () => {
-    for (const httpMessage of httpMessages) {
-      const samlDetection = await detectSamlStep(httpMessage, httpMessages);
-      if (samlDetection instanceof Error) {
-        console.error("Failed to detect SAML flow from HTTP message:", samlDetection);
-        continue;
-      } else if (!samlDetection) {
-        continue;
-      } else if (samlDetection.step === 4 || samlDetection.step === 5) {
-        return httpMessage;
-      }
-    }
-    return undefined;
-  })();
-  if (!httpMessage) {
-    return undefined;
-  }
-
-  const responseXml = await extractSamlResponseXml(httpMessage);
-  if (responseXml instanceof Error) {
-    console.warn("Failed to extract SAML Response XML:", responseXml);
-    return undefined;
-  }
-
-  return responseXml;
 }

--- a/src/report-page/common/types.ts
+++ b/src/report-page/common/types.ts
@@ -3,9 +3,21 @@
  * @license BSD-3-Clause
  */
 
+import { type CaptureSession } from "@/common/models/capture-session.ts";
+import { type FlowEntry } from "@/common/models/flow-entry.ts";
+import { type HttpMessage } from "@/common/models/http-message.ts";
+import { type SamlTrace } from "@/common/models/saml-trace.ts";
+
 export type ContentSectionId = SummarySectionId | SamlSectionId | HttpSectionId;
 export type SummarySectionId = "session-summary";
 export type SamlSectionId = "saml-request" | "saml-response";
 export type HttpSectionId = `http-${number}`;
 
 export type ArrowClickHandler = (sectionId: ContentSectionId) => void;
+
+export type FlowData = {
+  flowEntry: FlowEntry;
+  captureSession: CaptureSession;
+  samlTraces: SamlTrace[];
+  httpMessages: HttpMessage[];
+};

--- a/src/report-page/content/content-builders.test.ts
+++ b/src/report-page/content/content-builders.test.ts
@@ -472,7 +472,6 @@ describe("buildResponseDetails", () => {
 describe("buildHttpMessageDetails", () => {
   const baseFields = {
     createdAt: "2026-01-01T00:00:00Z",
-    imported: false,
     fetchRequestId: "req-1",
     url: "https://example.com/path",
     method: "POST",

--- a/src/report-page/dev/sample-flow.ts
+++ b/src/report-page/dev/sample-flow.ts
@@ -4,7 +4,16 @@
  */
 
 import { Base64 } from "js-base64";
-import { type HttpMessage } from "@/common/models/http-message.ts";
+import { type CaptureSession } from "@/common/models/capture-session.ts";
+import { type FlowEntry } from "@/common/models/flow-entry.ts";
+import { type HttpMessage, type HttpRequest } from "@/common/models/http-message.ts";
+import { type SamlDetection } from "@/common/models/saml-detection.ts";
+import { type SamlTrace, newSamlTrace } from "@/common/models/saml-trace.ts";
+import {
+  detectSamlStepFromHttpRequest,
+  detectSamlStepFromHttpResponse,
+} from "@/common/services/saml-detector.ts";
+import { type FlowData } from "@/report-page/common/types.ts";
 import sampleAuthnRequestXmlRaw from "./authn-request.xml?raw";
 import samlFailureResponseXmlRaw from "./response-failure.xml?raw";
 import samlSuccessResponseXmlRaw from "./response-success.xml?raw";
@@ -19,8 +28,37 @@ const samlSuccessResponseXml = samlSuccessResponseXmlRaw.trim();
 const samlFailureResponseXml = samlFailureResponseXmlRaw.trim();
 const samlUnknownResponseXml = samlUnknownResponseXmlRaw.trim();
 
-export async function buildSampleHttpMessages(): Promise<HttpMessage[]> {
+const sampleFlowId = "flow-sample";
+const sampleCaptureSessionId = "cs-sample";
+
+export async function buildSampleFlowData(): Promise<FlowData> {
   const sample = new URLSearchParams(window.location.search).get("sample");
+
+  const allHttpMessages = await buildSampleHttpMessages(sample);
+  const allSamlTraces = await buildSampleSamlTraces(allHttpMessages);
+
+  const httpMessages = selectSampleHttpMessages(sample, allHttpMessages);
+  const httpMessageIds = new Set(httpMessages.map((m) => m.id));
+  const samlTraces = allSamlTraces.filter((t) => httpMessageIds.has(t.httpMessageId));
+
+  const flowEntry: FlowEntry = {
+    id: sampleFlowId,
+    captureSessionId: sampleCaptureSessionId,
+    protocol: "saml",
+    correlationKey: allSamlTraces[0]?.sessionId ?? "",
+  };
+
+  const captureSession: CaptureSession = {
+    id: sampleCaptureSessionId,
+    imported: false,
+    startedAt: "2004-12-05T09:21:57.000Z",
+    endedAt: "2004-12-05T09:22:06.000Z",
+  };
+
+  return { flowEntry, captureSession, samlTraces, httpMessages };
+}
+
+async function buildSampleHttpMessages(sample: string | null): Promise<HttpMessage[]> {
   const samlResponseXml =
     sample === "failure"
       ? samlFailureResponseXml
@@ -151,28 +189,90 @@ export async function buildSampleHttpMessages(): Promise<HttpMessage[]> {
     pairedHttpRequestId: httpRequest5.id,
   } satisfies HttpMessage;
 
-  const allMessages = [
-    httpRequest1,
-    httpResponse2,
-    httpRequest3,
-    httpResponse4,
-    httpRequest5,
-    httpResponse6,
-  ];
+  return [httpRequest1, httpResponse2, httpRequest3, httpResponse4, httpRequest5, httpResponse6];
+}
 
+function selectSampleHttpMessages(
+  sample: string | null,
+  allHttpMessages: HttpMessage[],
+): HttpMessage[] {
   const stepMatch = sample?.match(/^step([2-6])$/);
   if (stepMatch) {
-    return allMessages.slice(0, Number(stepMatch[1]));
+    return allHttpMessages.slice(0, Number(stepMatch[1]));
   }
 
   // Remove specific steps to simulate missing data (e.g., ?sample=missing-3,4)
   const missingMatch = sample?.match(/^missing-([\d,]+)$/);
   if (missingMatch) {
     const missingSteps = new Set(missingMatch[1]!.split(",").map(Number));
-    return allMessages.filter((_, i) => !missingSteps.has(i + 1));
+    return allHttpMessages.filter((_, i) => !missingSteps.has(i + 1));
   }
 
-  return allMessages;
+  return allHttpMessages;
+}
+
+async function buildSampleSamlTraces(httpMessages: HttpMessage[]): Promise<SamlTrace[]> {
+  const samlTraces: SamlTrace[] = [];
+
+  for (const httpMessage of httpMessages) {
+    const pairedHttpRequest =
+      httpMessage.stage === "Response"
+        ? findPairedHttpRequest(httpMessage.pairedHttpRequestId, httpMessages)
+        : undefined;
+
+    const detection = await detectSamlStep(httpMessage, pairedHttpRequest);
+    if (detection instanceof Error) {
+      console.error("Failed to detect SAML step from sample message:", detection);
+      continue;
+    } else if (!detection) {
+      continue;
+    }
+
+    if (detection.step === 2 && pairedHttpRequest !== undefined) {
+      pushSamlTrace(
+        samlTraces,
+        { step: 1, correlationKey: detection.correlationKey },
+        pairedHttpRequest,
+      );
+    }
+    pushSamlTrace(samlTraces, detection, httpMessage);
+  }
+
+  return samlTraces;
+}
+
+async function detectSamlStep(
+  httpMessage: HttpMessage,
+  pairedHttpRequest: HttpRequest | undefined,
+): Promise<SamlDetection | undefined | Error> {
+  if (httpMessage.stage === "Request") {
+    return detectSamlStepFromHttpRequest(httpMessage);
+  } else if (pairedHttpRequest === undefined) {
+    return new Error(`No paired HTTP request for HTTP response: ${httpMessage.id}`);
+  } else {
+    return detectSamlStepFromHttpResponse(httpMessage, pairedHttpRequest);
+  }
+}
+
+function findPairedHttpRequest(
+  pairedHttpRequestId: string,
+  httpMessages: HttpMessage[],
+): HttpRequest | undefined {
+  const pairedHttpRequest = httpMessages.find((m) => m.id === pairedHttpRequestId);
+  return pairedHttpRequest?.stage === "Request" ? pairedHttpRequest : undefined;
+}
+
+function pushSamlTrace(
+  samlTraces: SamlTrace[],
+  detection: SamlDetection,
+  httpMessage: HttpMessage,
+): void {
+  const samlTrace = newSamlTrace(sampleFlowId, detection, httpMessage);
+  if (samlTrace instanceof Error) {
+    console.error("Failed to build SAML trace from sample message:", samlTrace);
+    return;
+  }
+  samlTraces.push(samlTrace);
 }
 
 //

--- a/src/report-page/dev/sample-flow.ts
+++ b/src/report-page/dev/sample-flow.ts
@@ -73,7 +73,6 @@ async function buildSampleHttpMessages(sample: string | null): Promise<HttpMessa
   // Step 1: User -> SP
   const httpRequest1 = {
     id: "msg-001",
-    imported: false,
     stage: "Request" as const,
     createdAt: "2004-12-05T09:21:58.000Z",
     fetchRequestId: "req-001",
@@ -86,7 +85,6 @@ async function buildSampleHttpMessages(sample: string | null): Promise<HttpMessa
   // Step 2: SP -> User
   const httpResponse2 = {
     id: "msg-002",
-    imported: false,
     stage: "Response" as const,
     createdAt: "2004-12-05T09:21:59.000Z",
     fetchRequestId: "req-001",
@@ -105,7 +103,6 @@ async function buildSampleHttpMessages(sample: string | null): Promise<HttpMessa
   // Step 3: User -> IdP
   const httpRequest3 = {
     id: "msg-003",
-    imported: false,
     stage: "Request" as const,
     createdAt: "2004-12-05T09:21:59.200Z",
     fetchRequestId: "req-002",
@@ -118,7 +115,6 @@ async function buildSampleHttpMessages(sample: string | null): Promise<HttpMessa
   // Step 4: IdP -> User
   const httpResponse4 = {
     id: "msg-004",
-    imported: false,
     stage: "Response" as const,
     createdAt: "2004-12-05T09:22:05.000Z",
     fetchRequestId: "req-002",
@@ -147,7 +143,6 @@ async function buildSampleHttpMessages(sample: string | null): Promise<HttpMessa
   // Step 5: User -> SP
   const httpRequest5 = {
     id: "msg-005",
-    imported: false,
     stage: "Request" as const,
     createdAt: "2004-12-05T09:22:05.100Z",
     fetchRequestId: "req-003",
@@ -164,7 +159,6 @@ async function buildSampleHttpMessages(sample: string | null): Promise<HttpMessa
   const isSuccess = sample !== "failure" && sample !== "unknown";
   const httpResponse6 = {
     id: "msg-006",
-    imported: false,
     stage: "Response" as const,
     createdAt: "2004-12-05T09:22:05.500Z",
     fetchRequestId: "req-003",

--- a/src/report-page/sidebar/sidebar-builders.test.ts
+++ b/src/report-page/sidebar/sidebar-builders.test.ts
@@ -14,7 +14,6 @@ import { buildHttpMessageDataRecord } from "./sidebar-builders.ts";
 const baseFields = {
   id: "msg-1",
   createdAt: "2026-01-01T00:00:00Z",
-  imported: false,
   fetchRequestId: "req-1",
   headers: [],
   body: "",

--- a/src/service-worker/saml-tracer.test.ts
+++ b/src/service-worker/saml-tracer.test.ts
@@ -45,7 +45,6 @@ beforeEach(() => {
 function makeRequest(overrides: Record<string, unknown> = {}): HttpRequest {
   return {
     createdAt: "2026-01-01T00:00:00Z",
-    imported: false,
     stage: "Request",
     fetchRequestId: "req-1",
     headers: [],
@@ -59,7 +58,6 @@ function makeRequest(overrides: Record<string, unknown> = {}): HttpRequest {
 function makeResponse(overrides: Record<string, unknown> = {}): HttpResponse {
   return {
     createdAt: "2026-01-01T00:00:00Z",
-    imported: false,
     stage: "Response",
     fetchRequestId: "req-1",
     headers: [{ name: "Date", value: "Thu, 01 Jan 2026 00:00:00 GMT" }],

--- a/src/service-worker/saml-tracer.test.ts
+++ b/src/service-worker/saml-tracer.test.ts
@@ -5,7 +5,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type HttpRequest, type HttpResponse } from "@/common/models/http-message.ts";
-import { storeHttpMessage } from "@/common/services/http-store.ts";
+import { retrieveHttpMessages, storeHttpMessage } from "@/common/services/http-store.ts";
 import {
   detectSamlStepFromHttpRequest,
   detectSamlStepFromHttpResponse,
@@ -20,6 +20,7 @@ vi.mock("@/common/services/saml-detector.ts", () => ({
 }));
 
 vi.mock("@/common/services/http-store.ts", () => ({
+  retrieveHttpMessages: vi.fn(),
   storeHttpMessage: vi.fn(),
 }));
 
@@ -34,6 +35,7 @@ vi.mock("@/service-worker/capture-manager.ts", () => ({
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(getOngoingCaptureSessionId).mockResolvedValue("capture-session-1");
+  vi.mocked(retrieveHttpMessages).mockResolvedValue([]);
 });
 
 //
@@ -217,5 +219,69 @@ describe("processHttpResponse", () => {
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("store error");
     expect(recordSamlTrace).not.toHaveBeenCalled();
+  });
+
+  it("uses the stored request instead of the recreated one when it exists", async () => {
+    const storedRequest = makeRequest({ id: "stored-1", url: "https://sp.example.com/acs" });
+    const pairedRequest = makeRequest({ id: "recreated-1", url: "https://sp.example.com/acs" });
+    const response = makeResponse({ pairedHttpRequestId: "recreated-1" });
+    vi.mocked(retrieveHttpMessages).mockResolvedValue([storedRequest]);
+    vi.mocked(detectSamlStepFromHttpResponse).mockResolvedValue({
+      step: 6,
+      correlationKey: "session-1",
+    });
+    vi.mocked(storeHttpMessage).mockResolvedValue(undefined);
+    vi.mocked(recordSamlTrace).mockResolvedValue(undefined);
+
+    const result = await processHttpResponse(1, response, pairedRequest);
+
+    expect(result).toBe("session-1");
+    expect(retrieveHttpMessages).toHaveBeenCalledExactlyOnceWith(1, "session-1");
+    expect(storeHttpMessage).toHaveBeenCalledExactlyOnceWith(
+      { ...response, pairedHttpRequestId: "stored-1" },
+      1,
+      "session-1",
+    );
+    expect(recordSamlTrace).toHaveBeenCalledExactlyOnceWith(
+      "capture-session-1",
+      1,
+      { step: 6, correlationKey: "session-1" },
+      { ...response, pairedHttpRequestId: "stored-1" },
+      storedRequest,
+    );
+  });
+
+  it("ignores stored messages of other fetch request IDs", async () => {
+    const storedRequest = makeRequest({ id: "stored-1", fetchRequestId: "req-other" });
+    const pairedRequest = makeRequest({ id: "recreated-1" });
+    const response = makeResponse({ pairedHttpRequestId: "recreated-1" });
+    vi.mocked(retrieveHttpMessages).mockResolvedValue([storedRequest]);
+    vi.mocked(detectSamlStepFromHttpResponse).mockResolvedValue({
+      step: 2,
+      correlationKey: "session-1",
+    });
+    vi.mocked(storeHttpMessage).mockResolvedValue(undefined);
+    vi.mocked(recordSamlTrace).mockResolvedValue(undefined);
+
+    await processHttpResponse(1, response, pairedRequest);
+
+    expect(storeHttpMessage).toHaveBeenNthCalledWith(1, pairedRequest, 1, "session-1");
+    expect(storeHttpMessage).toHaveBeenNthCalledWith(2, response, 1, "session-1");
+  });
+
+  it("returns Error when retrieving stored messages fails", async () => {
+    const pairedRequest = makeRequest();
+    const response = makeResponse();
+    vi.mocked(retrieveHttpMessages).mockResolvedValue(new Error("retrieve error"));
+    vi.mocked(detectSamlStepFromHttpResponse).mockResolvedValue({
+      step: 2,
+      correlationKey: "session-1",
+    });
+
+    const result = await processHttpResponse(1, response, pairedRequest);
+
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toBe("retrieve error");
+    expect(storeHttpMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/service-worker/saml-tracer.ts
+++ b/src/service-worker/saml-tracer.ts
@@ -9,7 +9,7 @@ import {
   debugHttpRequest,
   debugHttpResponse,
 } from "@/common/models/http-message.ts";
-import { storeHttpMessage } from "@/common/services/http-store.ts";
+import { retrieveHttpMessages, storeHttpMessage } from "@/common/services/http-store.ts";
 import {
   detectSamlStepFromHttpRequest,
   detectSamlStepFromHttpResponse,
@@ -73,12 +73,34 @@ export async function processHttpResponse(
     return undefined;
   }
 
-  const pairStoreError = await storeHttpMessage(pairedHttpRequest, tabId, detection.correlationKey);
-  if (pairStoreError) {
-    return pairStoreError;
+  const storedHttpMessages = await retrieveHttpMessages(tabId, detection.correlationKey);
+  if (storedHttpMessages instanceof Error) {
+    return storedHttpMessages;
   }
 
-  const httpStoreError = await storeHttpMessage(httpResponse, tabId, detection.correlationKey);
+  const storedPairedHttpRequest = storedHttpMessages.find(
+    (m): m is HttpRequest =>
+      m.stage === "Request" && m.fetchRequestId === httpResponse.fetchRequestId,
+  );
+
+  const httpRequest = storedPairedHttpRequest ?? pairedHttpRequest;
+  const httpResponseToStore =
+    storedPairedHttpRequest === undefined
+      ? httpResponse
+      : { ...httpResponse, pairedHttpRequestId: storedPairedHttpRequest.id };
+
+  if (storedPairedHttpRequest === undefined) {
+    const pairStoreError = await storeHttpMessage(httpRequest, tabId, detection.correlationKey);
+    if (pairStoreError) {
+      return pairStoreError;
+    }
+  }
+
+  const httpStoreError = await storeHttpMessage(
+    httpResponseToStore,
+    tabId,
+    detection.correlationKey,
+  );
   if (httpStoreError) {
     return httpStoreError;
   }
@@ -87,8 +109,8 @@ export async function processHttpResponse(
     captureSessionId,
     tabId,
     detection,
-    httpResponse,
-    pairedHttpRequest,
+    httpResponseToStore,
+    httpRequest,
   );
   if (recordError) {
     return recordError;


### PR DESCRIPTION
- **Read report page data through SAML traces**
- **Drop imported flag from HTTP messages and traces**
- **Merge summarizeSamlSession into summarizeSamlFlow**
- **Find HTTP messages through SAML traces for delete and export**
