### PR TITLE
Read and delete flow data by flow ID

### DIFF
--- a/src/common/models/saml-trace.test.ts
+++ b/src/common/models/saml-trace.test.ts
@@ -15,7 +15,6 @@ describe("isSamlTrace", () => {
       httpMessageId: "msg-1",
       observedAt: "2026-01-01T00:00:00Z",
       serverHostname: "sp.example.com",
-      sessionId: "abc123",
       action: "test action",
       step: 2,
       type: "IncomingAuthnRequest",
@@ -63,16 +62,6 @@ describe("isSamlTrace", () => {
 
   it("returns false when serverHostname is not a string", () => {
     expect(isSamlTrace({ ...makeTraceFields(), serverHostname: null })).toBe(false);
-  });
-
-  it("returns false when sessionId is missing", () => {
-    const msg = makeTraceFields();
-    delete msg.sessionId;
-    expect(isSamlTrace(msg)).toBe(false);
-  });
-
-  it("returns false when sessionId is not a string", () => {
-    expect(isSamlTrace({ ...makeTraceFields(), sessionId: 123 })).toBe(false);
   });
 
   it("returns false when optional samlStatusCode is not a string", () => {
@@ -124,7 +113,6 @@ describe("newSamlTrace", () => {
       httpMessageId: "msg-1",
       observedAt: "2026-01-01T00:00:00Z",
       serverHostname: "sp.example.com",
-      sessionId: "authn-req-1",
       step: 1,
       type: "UnauthenticatedResourceRequest",
       action: "User Agent requests a secured resource at Service Provider",
@@ -142,7 +130,6 @@ describe("newSamlTrace", () => {
       httpMessageId: "msg-1",
       observedAt: "2026-01-01T00:00:00Z",
       serverHostname: "sp.example.com",
-      sessionId: "authn-req-1",
       step: 2,
       type: "IncomingAuthnRequest",
       action: "Service Provider issues SAML AuthnRequest",
@@ -156,7 +143,6 @@ describe("newSamlTrace", () => {
     const result = newSamlTrace("flow-1", { step: 3, correlationKey: "authn-req-1" }, request);
 
     expect(result).toMatchObject({
-      sessionId: "authn-req-1",
       step: 3,
       type: "OutgoingAuthnRequest",
       serverHostname: "idp.example.org",
@@ -185,7 +171,6 @@ describe("newSamlTrace", () => {
     );
 
     expect(result).toMatchObject({
-      sessionId: "authn-req-1",
       step: 4,
       type: "IncomingResponse",
       action: "Identity Provider issues SAML Response",
@@ -203,7 +188,6 @@ describe("newSamlTrace", () => {
     );
 
     expect(result).toMatchObject({
-      sessionId: "authn-req-1",
       step: 5,
       type: "OutgoingResponse",
       action: "User Agent submits SAML Response to Service Provider",
@@ -217,7 +201,6 @@ describe("newSamlTrace", () => {
     const result = newSamlTrace("flow-1", { step: 6, correlationKey: "authn-req-1" }, response);
 
     expect(result).toMatchObject({
-      sessionId: "authn-req-1",
       step: 6,
       type: "AuthenticatedResourceResponse",
       action: "Service Provider returns the requested resource",

--- a/src/common/models/saml-trace.ts
+++ b/src/common/models/saml-trace.ts
@@ -23,7 +23,6 @@ type SamlTraceBase = {
   httpMessageId: string;
   observedAt: string;
   serverHostname: string;
-  sessionId: string;
   action: string;
 };
 
@@ -73,7 +72,6 @@ export function isSamlTrace(u: unknown): u is SamlTrace {
     typeof u.httpMessageId === "string" &&
     typeof u.observedAt === "string" &&
     typeof u.serverHostname === "string" &&
-    typeof u.sessionId === "string" &&
     (!("samlStatusCode" in u) || typeof u.samlStatusCode === "string")
   );
 }
@@ -94,7 +92,6 @@ export function newSamlTrace(
     httpMessageId: httpMessage.id,
     observedAt: httpMessage.observedAt,
     serverHostname: hostname,
-    sessionId: detection.correlationKey,
   };
 
   switch (detection.step) {
@@ -169,7 +166,7 @@ export const debugSamlTrace =
 async function debugSamlTraceImpl(samlTrace: SamlTrace) {
   const debug = await createLabeledDebugLogger([
     "SAML",
-    samlTrace.sessionId,
+    samlTrace.flowId,
     `Step ${samlTrace.step}`,
   ]);
   debug({ [samlTrace.type]: samlTrace });

--- a/src/common/services/flow-query.test.ts
+++ b/src/common/services/flow-query.test.ts
@@ -4,11 +4,21 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
+import { findFlowEntryById } from "@/common/services/flow-store.ts";
 import { findHttpMessagesByIds } from "@/common/services/http-store.ts";
-import { findSamlTraces } from "@/common/services/saml-store.ts";
-import { findHttpMessagesOfFlow } from "./flow-query.ts";
+import { findSamlTraces, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
+import {
+  findFlowEntriesByTabId,
+  findFlowEntryByCorrelationKeyInTab,
+  findHttpMessagesOfFlow,
+} from "./flow-query.ts";
+
+vi.mock("@/common/services/flow-store.ts", () => ({
+  findFlowEntryById: vi.fn(),
+}));
 
 vi.mock("@/common/services/http-store.ts", () => ({
   findHttpMessagesByIds: vi.fn(),
@@ -16,6 +26,7 @@ vi.mock("@/common/services/http-store.ts", () => ({
 
 vi.mock("@/common/services/saml-store.ts", () => ({
   findSamlTraces: vi.fn(),
+  findSamlTracesByFlowId: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -26,8 +37,12 @@ beforeEach(() => {
 // Helpers
 //
 
-function makeSamlTrace(httpMessageId: string, sessionId = "corr-1"): SamlTrace {
-  return { httpMessageId, sessionId } as SamlTrace;
+function makeSamlTrace(httpMessageId: string, flowId = "flow-1"): SamlTrace {
+  return { httpMessageId, flowId } as SamlTrace;
+}
+
+function makeFlowEntry(id: string, correlationKey = `corr-${id}`): FlowEntry {
+  return { id, captureSessionId: "cs-1", protocol: "saml", correlationKey };
 }
 
 function makeRequest(id: string): HttpMessage {
@@ -39,9 +54,16 @@ function makeResponse(id: string, pairedHttpRequestId: string): HttpMessage {
 }
 
 // Serves the given messages from the mocked store by their IDs
-function mockStore(...httpMessages: HttpMessage[]): void {
+function mockHttpStore(...httpMessages: HttpMessage[]): void {
   vi.mocked(findHttpMessagesByIds).mockImplementation(async (ids) =>
     httpMessages.filter((m) => ids.includes(m.id)),
+  );
+}
+
+// Serves the given flows from the mocked store by their IDs
+function mockFlowStore(...flowEntries: FlowEntry[]): void {
+  vi.mocked(findFlowEntryById).mockImplementation(async (id) =>
+    flowEntries.find((f) => f.id === id),
   );
 }
 
@@ -52,12 +74,12 @@ function mockStore(...httpMessages: HttpMessage[]): void {
 describe("findHttpMessagesOfFlow", () => {
   it("returns the HTTP messages referenced by the traces of the flow", async () => {
     const referenced = makeRequest("msg-1");
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-1")]);
-    mockStore(referenced, makeRequest("msg-2"));
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace("msg-1")]);
+    mockHttpStore(referenced, makeRequest("msg-2"));
 
-    const result = await findHttpMessagesOfFlow(1, "corr-1");
+    const result = await findHttpMessagesOfFlow("flow-1");
 
-    expect(findSamlTraces).toHaveBeenCalledWith(1);
+    expect(findSamlTracesByFlowId).toHaveBeenCalledWith("flow-1");
     expect(findHttpMessagesByIds).toHaveBeenNthCalledWith(1, ["msg-1"]);
     expect(result).toEqual([referenced]);
   });
@@ -65,10 +87,10 @@ describe("findHttpMessagesOfFlow", () => {
   it("includes the paired request of a referenced response", async () => {
     const pairedRequest = makeRequest("msg-1");
     const response = makeResponse("msg-2", "msg-1");
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-2")]);
-    mockStore(pairedRequest, response);
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace("msg-2")]);
+    mockHttpStore(pairedRequest, response);
 
-    const result = await findHttpMessagesOfFlow(1, "corr-1");
+    const result = await findHttpMessagesOfFlow("flow-1");
 
     expect(findHttpMessagesByIds).toHaveBeenNthCalledWith(2, ["msg-1"]);
     expect(result).toEqual([pairedRequest, response]);
@@ -77,48 +99,123 @@ describe("findHttpMessagesOfFlow", () => {
   it("does not look up a paired request that a trace references itself", async () => {
     const pairedRequest = makeRequest("msg-1");
     const response = makeResponse("msg-2", "msg-1");
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-1"), makeSamlTrace("msg-2")]);
-    mockStore(pairedRequest, response);
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue([
+      makeSamlTrace("msg-1"),
+      makeSamlTrace("msg-2"),
+    ]);
+    mockHttpStore(pairedRequest, response);
 
-    const result = await findHttpMessagesOfFlow(1, "corr-1");
+    const result = await findHttpMessagesOfFlow("flow-1");
 
     expect(findHttpMessagesByIds).toHaveBeenNthCalledWith(2, []);
     expect(result).toEqual([pairedRequest, response]);
   });
 
-  it("ignores the traces of other flows", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-1", "corr-2")]);
-    mockStore(makeRequest("msg-1"));
+  it("returns an error when the traces cannot be found", async () => {
+    const error = new Error("saml store error");
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue(error);
 
-    const result = await findHttpMessagesOfFlow(1, "corr-1");
+    expect(await findHttpMessagesOfFlow("flow-1")).toBe(error);
+    expect(findHttpMessagesByIds).not.toHaveBeenCalled();
+  });
 
-    expect(findHttpMessagesByIds).toHaveBeenNthCalledWith(1, []);
-    expect(result).toEqual([]);
+  it("returns an error when the HTTP messages cannot be found", async () => {
+    const error = new Error("http store error");
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue([]);
+    vi.mocked(findHttpMessagesByIds).mockResolvedValue(error);
+
+    expect(await findHttpMessagesOfFlow("flow-1")).toBe(error);
+  });
+
+  it("returns an error when the paired requests cannot be found", async () => {
+    const error = new Error("http store error");
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace("msg-2")]);
+    vi.mocked(findHttpMessagesByIds)
+      .mockResolvedValueOnce([makeResponse("msg-2", "msg-1")])
+      .mockResolvedValueOnce(error);
+
+    expect(await findHttpMessagesOfFlow("flow-1")).toBe(error);
+  });
+});
+
+describe("findFlowEntriesByTabId", () => {
+  it("returns the flows of the traces in the tab, newest first", async () => {
+    const flow1 = makeFlowEntry("flow-1");
+    const flow2 = makeFlowEntry("flow-2");
+    vi.mocked(findSamlTraces).mockResolvedValue([
+      makeSamlTrace("msg-1", "flow-1"),
+      makeSamlTrace("msg-2", "flow-1"),
+      makeSamlTrace("msg-3", "flow-2"),
+    ]);
+    mockFlowStore(flow1, flow2);
+
+    const result = await findFlowEntriesByTabId(1);
+
+    expect(findSamlTraces).toHaveBeenCalledWith(1);
+    expect(findFlowEntryById).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([flow2, flow1]);
+  });
+
+  it("returns an empty array when the tab has no traces", async () => {
+    vi.mocked(findSamlTraces).mockResolvedValue([]);
+
+    expect(await findFlowEntriesByTabId(1)).toEqual([]);
+    expect(findFlowEntryById).not.toHaveBeenCalled();
+  });
+
+  it("skips traces without a flow entry with a warning", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const flow1 = makeFlowEntry("flow-1");
+    vi.mocked(findSamlTraces).mockResolvedValue([
+      makeSamlTrace("msg-1", "flow-1"),
+      makeSamlTrace("msg-2", "flow-x"),
+    ]);
+    mockFlowStore(flow1);
+
+    expect(await findFlowEntriesByTabId(1)).toEqual([flow1]);
+    expect(consoleWarn).toHaveBeenCalledOnce();
   });
 
   it("returns an error when the traces cannot be found", async () => {
     const error = new Error("saml store error");
     vi.mocked(findSamlTraces).mockResolvedValue(error);
 
-    expect(await findHttpMessagesOfFlow(1, "corr-1")).toBe(error);
-    expect(findHttpMessagesByIds).not.toHaveBeenCalled();
+    expect(await findFlowEntriesByTabId(1)).toBe(error);
+    expect(findFlowEntryById).not.toHaveBeenCalled();
   });
 
-  it("returns an error when the HTTP messages cannot be found", async () => {
-    const error = new Error("http store error");
-    vi.mocked(findSamlTraces).mockResolvedValue([]);
-    vi.mocked(findHttpMessagesByIds).mockResolvedValue(error);
+  it("returns an error when a flow cannot be found", async () => {
+    const error = new Error("flow store error");
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-1")]);
+    vi.mocked(findFlowEntryById).mockResolvedValue(error);
 
-    expect(await findHttpMessagesOfFlow(1, "corr-1")).toBe(error);
+    expect(await findFlowEntriesByTabId(1)).toBe(error);
+  });
+});
+
+describe("findFlowEntryByCorrelationKeyInTab", () => {
+  it("returns the flow with the correlation key among the flows of the tab", async () => {
+    const flow2 = makeFlowEntry("flow-2");
+    vi.mocked(findSamlTraces).mockResolvedValue([
+      makeSamlTrace("msg-1", "flow-1"),
+      makeSamlTrace("msg-2", "flow-2"),
+    ]);
+    mockFlowStore(makeFlowEntry("flow-1"), flow2);
+
+    expect(await findFlowEntryByCorrelationKeyInTab(1, "corr-flow-2")).toEqual(flow2);
   });
 
-  it("returns an error when the paired requests cannot be found", async () => {
-    const error = new Error("http store error");
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-2")]);
-    vi.mocked(findHttpMessagesByIds)
-      .mockResolvedValueOnce([makeResponse("msg-2", "msg-1")])
-      .mockResolvedValueOnce(error);
+  it("returns undefined when no flow of the tab has the correlation key", async () => {
+    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-1", "flow-1")]);
+    mockFlowStore(makeFlowEntry("flow-1"));
 
-    expect(await findHttpMessagesOfFlow(1, "corr-1")).toBe(error);
+    expect(await findFlowEntryByCorrelationKeyInTab(1, "corr-x")).toBeUndefined();
+  });
+
+  it("returns an error when the flows cannot be found", async () => {
+    const error = new Error("saml store error");
+    vi.mocked(findSamlTraces).mockResolvedValue(error);
+
+    expect(await findFlowEntryByCorrelationKeyInTab(1, "corr-flow-1")).toBe(error);
   });
 });

--- a/src/common/services/flow-query.ts
+++ b/src/common/services/flow-query.ts
@@ -3,15 +3,19 @@
  * @license BSD-3-Clause
  */
 
+import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type HttpMessage } from "@/common/models/http-message.ts";
+import { findFlowEntryById } from "@/common/services/flow-store.ts";
 import { findHttpMessagesByIds } from "@/common/services/http-store.ts";
-import { findSamlTraces } from "@/common/services/saml-store.ts";
+import { findSamlTraces, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 
-export async function findHttpMessagesOfFlow(
-  tabId: number,
-  sessionId: string,
-): Promise<HttpMessage[] | Error> {
-  const httpMessages = await findTracedHttpMessages(tabId, sessionId);
+export async function findHttpMessagesOfFlow(flowId: string): Promise<HttpMessage[] | Error> {
+  const samlTraces = await findSamlTracesByFlowId(flowId);
+  if (samlTraces instanceof Error) {
+    return samlTraces;
+  }
+
+  const httpMessages = await findHttpMessagesByIds(samlTraces.map((t) => t.httpMessageId));
   if (httpMessages instanceof Error) {
     return httpMessages;
   }
@@ -32,18 +36,40 @@ export async function findHttpMessagesOfFlow(
   return [...httpMessages, ...pairedHttpRequests].toSorted((a, b) => (a.id < b.id ? -1 : 1));
 }
 
-async function findTracedHttpMessages(
-  tabId: number,
-  sessionId: string,
-): Promise<HttpMessage[] | Error> {
+export async function findFlowEntriesByTabId(tabId: number): Promise<FlowEntry[] | Error> {
   const samlTraces = await findSamlTraces(tabId);
   if (samlTraces instanceof Error) {
     return samlTraces;
   }
 
-  const httpMessageIds = samlTraces
-    .filter((t) => t.sessionId === sessionId)
-    .map((t) => t.httpMessageId);
+  const flowIds = [...new Set(samlTraces.map((t) => t.flowId))].toSorted((a, b) =>
+    a < b ? 1 : -1,
+  );
 
-  return await findHttpMessagesByIds(httpMessageIds);
+  const flowEntries: FlowEntry[] = [];
+  for (const flowId of flowIds) {
+    const flowEntry = await findFlowEntryById(flowId);
+    if (flowEntry instanceof Error) {
+      return flowEntry;
+    } else if (flowEntry === undefined) {
+      console.warn("No flow entry for the traces:", { flowId });
+      continue;
+    }
+
+    flowEntries.push(flowEntry);
+  }
+
+  return flowEntries;
+}
+
+export async function findFlowEntryByCorrelationKeyInTab(
+  tabId: number,
+  correlationKey: string,
+): Promise<FlowEntry | undefined | Error> {
+  const flowEntries = await findFlowEntriesByTabId(tabId);
+  if (flowEntries instanceof Error) {
+    return flowEntries;
+  }
+
+  return flowEntries.find((f) => f.correlationKey === correlationKey);
 }

--- a/src/common/services/flow-store.test.ts
+++ b/src/common/services/flow-store.test.ts
@@ -8,9 +8,11 @@ import { type FlowEntry, newFlowEntry } from "@/common/models/flow-entry.ts";
 import {
   getAllSessionStorageKeys,
   getSessionStorageItems,
+  removeSessionStorageItems,
   setSessionStorageItem,
 } from "@/common/utils/chrome-storage.ts";
 import {
+  deleteFlowEntry,
   findFlowEntriesByCaptureSessionId,
   findFlowEntryByCorrelationKey,
   findFlowEntryById,
@@ -20,6 +22,7 @@ import {
 vi.mock("@/common/utils/chrome-storage.ts", () => ({
   getAllSessionStorageKeys: vi.fn(),
   getSessionStorageItems: vi.fn(),
+  removeSessionStorageItems: vi.fn(),
   setSessionStorageItem: vi.fn(),
 }));
 
@@ -57,6 +60,27 @@ describe("saveFlowEntry", () => {
     vi.mocked(setSessionStorageItem).mockResolvedValue(error);
 
     const result = await saveFlowEntry(newFlowEntry("cs-1", "saml", "key"));
+
+    expect(result).toBe(error);
+  });
+});
+
+describe("deleteFlowEntry", () => {
+  it("removes the flow by its key", async () => {
+    vi.mocked(removeSessionStorageItems).mockResolvedValue(undefined);
+    const flow = newFlowEntry("cs-1", "saml", "_authn-request-id");
+
+    const result = await deleteFlowEntry(flow);
+
+    expect(result).toBeUndefined();
+    expect(removeSessionStorageItems).toHaveBeenCalledExactlyOnceWith([keyOf(flow)]);
+  });
+
+  it("propagates an error from the storage", async () => {
+    const error = new Error("storage failed");
+    vi.mocked(removeSessionStorageItems).mockResolvedValue(error);
+
+    const result = await deleteFlowEntry(newFlowEntry("cs-1", "saml", "key"));
 
     expect(result).toBe(error);
   });

--- a/src/common/services/flow-store.ts
+++ b/src/common/services/flow-store.ts
@@ -7,12 +7,17 @@ import { type FlowEntry, isFlowEntry } from "@/common/models/flow-entry.ts";
 import {
   getAllSessionStorageKeys,
   getSessionStorageItems,
+  removeSessionStorageItems,
   setSessionStorageItem,
 } from "@/common/utils/chrome-storage.ts";
 import { isObject } from "@/common/utils/type-guard.ts";
 
 export async function saveFlowEntry(flowEntry: FlowEntry): Promise<void | Error> {
   return await setSessionStorageItem(makeFlowEntryKey(flowEntry), flowEntry);
+}
+
+export async function deleteFlowEntry(flowEntry: FlowEntry): Promise<void | Error> {
+  return await removeSessionStorageItems([makeFlowEntryKey(flowEntry)]);
 }
 
 export async function findFlowEntriesByCaptureSessionId(

--- a/src/common/services/saml-recorder.test.ts
+++ b/src/common/services/saml-recorder.test.ts
@@ -113,7 +113,6 @@ describe("recordSamlTrace", () => {
       httpMessageId: pairedHttpRequest.id,
       observedAt: pairedHttpRequest.observedAt,
       serverHostname: "sp.example.com",
-      sessionId: "authn-req-1",
       action: "User Agent requests a secured resource at Service Provider",
     });
   });

--- a/src/common/services/saml-store.test.ts
+++ b/src/common/services/saml-store.test.ts
@@ -11,7 +11,12 @@ import {
   removeSessionStorageItems,
   setSessionStorageItem,
 } from "@/common/utils/chrome-storage.ts";
-import { deleteSamlTraces, findSamlTraces, saveSamlTrace } from "./saml-store.ts";
+import {
+  deleteSamlTracesByFlowId,
+  findSamlTraces,
+  findSamlTracesByFlowId,
+  saveSamlTrace,
+} from "./saml-store.ts";
 
 vi.mock("@/common/utils/chrome-storage.ts", () => ({
   getAllSessionStorageKeys: vi.fn(),
@@ -105,16 +110,64 @@ describe("findSamlTraces", () => {
   });
 });
 
-describe("deleteSamlTraces", () => {
-  it("removes only the traces of the tab and session", async () => {
-    await saveSamlTrace(makeTrace({ id: "trace-1", sessionId: "session-1" }), 1);
-    await saveSamlTrace(makeTrace({ id: "trace-2", sessionId: "session-2" }), 1);
-    await saveSamlTrace(makeTrace({ id: "trace-3", sessionId: "session-1" }), 2);
+describe("findSamlTracesByFlowId", () => {
+  it("returns the traces of the flow across tabs in id order", async () => {
+    await saveSamlTrace(makeTrace({ id: "trace-2", flowId: "flow-1" }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }), 2);
+    await saveSamlTrace(makeTrace({ id: "trace-3", flowId: "flow-2" }), 1);
 
-    const result = await deleteSamlTraces(1, "session-1");
+    const result = await findSamlTracesByFlowId("flow-1");
+
+    expect(result).not.toBeInstanceOf(Error);
+    expect((result as SamlTrace[]).map((t) => t.id)).toEqual(["trace-1", "trace-2"]);
+  });
+
+  it("reads only the items with matching keys", async () => {
+    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-2", flowId: "flow-2" }), 1);
+
+    await findSamlTracesByFlowId("flow-1");
+
+    expect(getSessionStorageItems).toHaveBeenCalledWith([
+      '{"id":"trace-1","kind":"trace","tabId":1,"flowId":"flow-1"}',
+    ]);
+  });
+
+  it("propagates an error from the storage", async () => {
+    const error = new Error("storage error");
+    vi.mocked(getAllSessionStorageKeys).mockResolvedValue(error);
+
+    expect(await findSamlTracesByFlowId("flow-1")).toBe(error);
+  });
+});
+
+describe("deleteSamlTracesByFlowId", () => {
+  it("removes only the traces of the flow", async () => {
+    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-2", flowId: "flow-2" }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-3", flowId: "flow-1" }), 2);
+
+    const result = await deleteSamlTracesByFlowId("flow-1");
 
     expect(result).toBeUndefined();
+    expect(getSessionStorageItems).not.toHaveBeenCalled();
     expect(((await findSamlTraces(1)) as SamlTrace[]).map((t) => t.id)).toEqual(["trace-2"]);
-    expect(((await findSamlTraces(2)) as SamlTrace[]).map((t) => t.id)).toEqual(["trace-3"]);
+    expect(await findSamlTraces(2)).toEqual([]);
+  });
+
+  it("propagates an error from the key retrieval", async () => {
+    const error = new Error("storage error");
+    vi.mocked(getAllSessionStorageKeys).mockResolvedValue(error);
+
+    expect(await deleteSamlTracesByFlowId("flow-1")).toBe(error);
+    expect(removeSessionStorageItems).not.toHaveBeenCalled();
+  });
+
+  it("propagates an error from the removal", async () => {
+    const error = new Error("storage error");
+    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }), 1);
+    vi.mocked(removeSessionStorageItems).mockResolvedValue(error);
+
+    expect(await deleteSamlTracesByFlowId("flow-1")).toBe(error);
   });
 });

--- a/src/common/services/saml-store.test.ts
+++ b/src/common/services/saml-store.test.ts
@@ -52,7 +52,6 @@ function makeTrace(overrides: Record<string, unknown> = {}): SamlTrace {
     httpMessageId: "msg-1",
     observedAt: "2026-01-01T00:00:00Z",
     serverHostname: "sp.example.com",
-    sessionId: "session-1",
     action: "test action",
     step: 2,
     type: "IncomingAuthnRequest",

--- a/src/common/services/saml-store.ts
+++ b/src/common/services/saml-store.ts
@@ -16,54 +16,59 @@ export async function saveSamlTrace(samlTrace: SamlTrace, tabId: number): Promis
   return await setSessionStorageItem(makeSamlTraceKey(samlTrace, tabId), samlTrace);
 }
 
-export async function deleteSamlTraces(tabId: number, sessionId: string): Promise<void | Error> {
-  const entries = await findSamlTraceEntriesBy((k) => k.tabId === tabId);
-  if (entries instanceof Error) {
-    return entries;
+export async function deleteSamlTracesByFlowId(flowId: string): Promise<void | Error> {
+  const keys = await findSamlTraceKeysBy((k) => k.flowId === flowId);
+  if (keys instanceof Error) {
+    return keys;
   }
 
-  const keys = entries
-    .filter(([, samlTrace]) => samlTrace.sessionId === sessionId)
-    .map(([key]) => key);
   return await removeSessionStorageItems(keys);
 }
 
 export async function findSamlTraces(tabId: number): Promise<SamlTrace[] | Error> {
-  const entries = await findSamlTraceEntriesBy((k) => k.tabId === tabId);
-  if (entries instanceof Error) {
-    return entries;
-  }
-
-  return entries.map(([, samlTrace]) => samlTrace);
+  return await findSamlTracesBy((k) => k.tabId === tabId);
 }
 
-async function findSamlTraceEntriesBy(
-  predicate: (keyFields: SamlTraceKeyFields) => boolean,
-): Promise<[string, SamlTrace][] | Error> {
-  const allKeys = await getAllSessionStorageKeys();
-  if (allKeys instanceof Error) {
-    return allKeys;
-  }
+export async function findSamlTracesByFlowId(flowId: string): Promise<SamlTrace[] | Error> {
+  return await findSamlTracesBy((k) => k.flowId === flowId);
+}
 
-  const keys = allKeys.filter((k) => {
-    const keyFields = parseSamlTraceKey(k);
-    return keyFields !== undefined && predicate(keyFields);
-  });
+async function findSamlTracesBy(
+  predicate: (keyFields: SamlTraceKeyFields) => boolean,
+): Promise<SamlTrace[] | Error> {
+  const keys = await findSamlTraceKeysBy(predicate);
+  if (keys instanceof Error) {
+    return keys;
+  }
 
   const items = await getSessionStorageItems(keys);
   if (items instanceof Error) {
     return items;
   }
 
-  return Object.entries(items)
-    .filter((entry): entry is [string, SamlTrace] => {
-      const valid = isSamlTrace(entry[1]);
+  return Object.values(items)
+    .filter((t): t is SamlTrace => {
+      const valid = isSamlTrace(t);
       if (!valid) {
-        console.warn("Invalid SAML trace:", entry[1]);
+        console.warn("Invalid SAML trace:", t);
       }
       return valid;
     })
-    .toSorted(([, a], [, b]) => (a.id < b.id ? -1 : 1));
+    .toSorted((a, b) => (a.id < b.id ? -1 : 1));
+}
+
+async function findSamlTraceKeysBy(
+  predicate: (keyFields: SamlTraceKeyFields) => boolean,
+): Promise<string[] | Error> {
+  const allKeys = await getAllSessionStorageKeys();
+  if (allKeys instanceof Error) {
+    return allKeys;
+  }
+
+  return allKeys.filter((k) => {
+    const keyFields = parseSamlTraceKey(k);
+    return keyFields !== undefined && predicate(keyFields);
+  });
 }
 
 const samlTraceKind = "trace";

--- a/src/common/services/saml-summarizer.test.ts
+++ b/src/common/services/saml-summarizer.test.ts
@@ -20,7 +20,6 @@ function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
     httpMessageId: "msg-1",
     observedAt: "2026-01-01T00:00:00.000Z",
     serverHostname: "sp.example.com",
-    sessionId: "session-1",
     action: "test action",
     step: 2,
     type: "IncomingAuthnRequest",

--- a/src/common/services/session-archiver.test.ts
+++ b/src/common/services/session-archiver.test.ts
@@ -4,10 +4,14 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { newHar, toHttpMessages } from "@/common/models/http-archive.ts";
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { saveEventRecord } from "@/common/services/event-store.ts";
-import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import {
+  findFlowEntryByCorrelationKeyInTab,
+  findHttpMessagesOfFlow,
+} from "@/common/services/flow-query.ts";
 import { saveHttpMessage } from "@/common/services/http-store.ts";
 import {
   detectSamlStepFromHttpRequest,
@@ -26,6 +30,7 @@ vi.mock("@/common/services/event-store.ts", () => ({
 }));
 
 vi.mock("@/common/services/flow-query.ts", () => ({
+  findFlowEntryByCorrelationKeyInTab: vi.fn(),
   findHttpMessagesOfFlow: vi.fn(),
 }));
 
@@ -48,19 +53,48 @@ beforeEach(() => {
 });
 
 describe("dumpSessionArchive", () => {
+  const flowEntry: FlowEntry = {
+    id: "flow-1",
+    captureSessionId: "cs-1",
+    protocol: "saml",
+    correlationKey: "session-1",
+  };
+
   it("returns HAR string on success", async () => {
     const httpMessages = [{} as HttpMessage];
+    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(flowEntry);
     vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(httpMessages);
     vi.mocked(newHar).mockReturnValue('{"log":{}}');
 
     const result = await dumpSessionArchive(1, "session-1");
 
-    expect(findHttpMessagesOfFlow).toHaveBeenCalledWith(1, "session-1");
+    expect(findFlowEntryByCorrelationKeyInTab).toHaveBeenCalledWith(1, "session-1");
+    expect(findHttpMessagesOfFlow).toHaveBeenCalledWith("flow-1");
     expect(newHar).toHaveBeenCalledWith(httpMessages);
     expect(result).toBe('{"log":{}}');
   });
 
+  it("returns Error when the flow cannot be found", async () => {
+    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(new Error("storage error"));
+
+    const result = await dumpSessionArchive(1, "session-1");
+
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toBe("storage error");
+    expect(findHttpMessagesOfFlow).not.toHaveBeenCalled();
+  });
+
+  it("returns Error when no flow has the session ID", async () => {
+    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(undefined);
+
+    const result = await dumpSessionArchive(1, "session-1");
+
+    expect(result).toBeInstanceOf(Error);
+    expect(findHttpMessagesOfFlow).not.toHaveBeenCalled();
+  });
+
   it("returns Error when findHttpMessagesOfFlow fails", async () => {
+    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(flowEntry);
     vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(new Error("storage error"));
 
     const result = await dumpSessionArchive(1, "session-1");

--- a/src/common/services/session-archiver.ts
+++ b/src/common/services/session-archiver.ts
@@ -12,7 +12,10 @@ import {
 } from "@/common/models/http-message.ts";
 import { type SamlDetection } from "@/common/models/saml-detection.ts";
 import { saveEventRecord } from "@/common/services/event-store.ts";
-import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import {
+  findFlowEntryByCorrelationKeyInTab,
+  findHttpMessagesOfFlow,
+} from "@/common/services/flow-query.ts";
 import { saveHttpMessage } from "@/common/services/http-store.ts";
 import {
   detectSamlStepFromHttpRequest,
@@ -31,7 +34,14 @@ export async function dumpSessionArchive(
   tabId: number,
   sessionId: string,
 ): Promise<string | Error> {
-  const httpMessages = await findHttpMessagesOfFlow(tabId, sessionId);
+  const flowEntry = await findFlowEntryByCorrelationKeyInTab(tabId, sessionId);
+  if (flowEntry instanceof Error) {
+    return flowEntry;
+  } else if (flowEntry === undefined) {
+    return new Error("Flow not found");
+  }
+
+  const httpMessages = await findHttpMessagesOfFlow(flowEntry.id);
   if (httpMessages instanceof Error) {
     return httpMessages;
   }

--- a/src/common/services/session-manager.test.ts
+++ b/src/common/services/session-manager.test.ts
@@ -14,6 +14,7 @@ import {
   findFlowEntryByCorrelationKeyInTab,
   findHttpMessagesOfFlow,
 } from "@/common/services/flow-query.ts";
+import { deleteFlowEntry } from "@/common/services/flow-store.ts";
 import { deleteHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTracesByFlowId, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 import { isAttached } from "@/common/utils/chrome-debugger.ts";
@@ -27,6 +28,10 @@ vi.mock("@/common/services/flow-query.ts", () => ({
   findFlowEntriesByTabId: vi.fn(),
   findFlowEntryByCorrelationKeyInTab: vi.fn(),
   findHttpMessagesOfFlow: vi.fn(),
+}));
+
+vi.mock("@/common/services/flow-store.ts", () => ({
+  deleteFlowEntry: vi.fn(),
 }));
 
 vi.mock("@/common/services/http-store.ts", () => ({
@@ -52,6 +57,7 @@ beforeEach(() => {
   vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(makeFlowEntry());
   vi.mocked(findHttpMessagesOfFlow).mockResolvedValue([]);
   vi.mocked(deleteSamlTracesByFlowId).mockResolvedValue(undefined);
+  vi.mocked(deleteFlowEntry).mockResolvedValue(undefined);
   vi.mocked(deleteHttpMessages).mockResolvedValue(undefined);
 });
 
@@ -66,7 +72,6 @@ function makeSamlTrace(overrides: Partial<SamlTrace>): SamlTrace {
     httpMessageId: "msg-1",
     observedAt: "2026-01-01T00:00:00.000Z",
     serverHostname: "sp.example.com",
-    sessionId: "corr-1",
     action: "test action",
     step: 2,
     type: "IncomingAuthnRequest",
@@ -208,7 +213,8 @@ describe("getSessionSummaries", () => {
 });
 
 describe("deleteSession", () => {
-  it("deletes the traces and then the HTTP messages of the flow", async () => {
+  it("deletes the traces, the flow, and then the HTTP messages of the flow", async () => {
+    const flowEntry = makeFlowEntry();
     const httpMessages = [{ id: "msg-1" } as HttpMessage];
     vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(httpMessages);
 
@@ -216,10 +222,12 @@ describe("deleteSession", () => {
     expect(findFlowEntryByCorrelationKeyInTab).toHaveBeenCalledWith(1, "corr-1");
     expect(findHttpMessagesOfFlow).toHaveBeenCalledWith("flow-1");
     expect(deleteSamlTracesByFlowId).toHaveBeenCalledWith("flow-1");
+    expect(deleteFlowEntry).toHaveBeenCalledWith(flowEntry);
     expect(deleteHttpMessages).toHaveBeenCalledWith(httpMessages);
-    expect(vi.mocked(deleteSamlTracesByFlowId).mock.invocationCallOrder[0]).toBeLessThan(
-      vi.mocked(deleteHttpMessages).mock.invocationCallOrder[0]!,
+    const order = [deleteSamlTracesByFlowId, deleteFlowEntry, deleteHttpMessages].map(
+      (fn) => vi.mocked(fn).mock.invocationCallOrder[0]!,
     );
+    expect(order).toEqual(order.toSorted((a, b) => a - b));
   });
 
   it("does nothing with a warning when no flow has the session ID", async () => {
@@ -252,6 +260,15 @@ describe("deleteSession", () => {
   it("returns an error when the trace deletion fails", async () => {
     const error = new Error("saml delete error");
     vi.mocked(deleteSamlTracesByFlowId).mockResolvedValue(error);
+
+    expect(await deleteSession(1, "corr-1")).toBe(error);
+    expect(deleteFlowEntry).not.toHaveBeenCalled();
+    expect(deleteHttpMessages).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the flow deletion fails", async () => {
+    const error = new Error("flow delete error");
+    vi.mocked(deleteFlowEntry).mockResolvedValue(error);
 
     expect(await deleteSession(1, "corr-1")).toBe(error);
     expect(deleteHttpMessages).not.toHaveBeenCalled();

--- a/src/common/services/session-manager.test.ts
+++ b/src/common/services/session-manager.test.ts
@@ -9,10 +9,13 @@ import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { getCaptureSession } from "@/common/services/capture-query.ts";
-import { findFlowEntryById } from "@/common/services/flow-store.ts";
-import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import {
+  findFlowEntriesByTabId,
+  findFlowEntryByCorrelationKeyInTab,
+  findHttpMessagesOfFlow,
+} from "@/common/services/flow-query.ts";
 import { deleteHttpMessages } from "@/common/services/http-store.ts";
-import { deleteSamlTraces, findSamlTraces } from "@/common/services/saml-store.ts";
+import { deleteSamlTracesByFlowId, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 import { isAttached } from "@/common/utils/chrome-debugger.ts";
 import { deleteSession, getSessionSummaries } from "./session-manager.ts";
 
@@ -20,11 +23,9 @@ vi.mock("@/common/services/capture-query.ts", () => ({
   getCaptureSession: vi.fn(),
 }));
 
-vi.mock("@/common/services/flow-store.ts", () => ({
-  findFlowEntryById: vi.fn(),
-}));
-
 vi.mock("@/common/services/flow-query.ts", () => ({
+  findFlowEntriesByTabId: vi.fn(),
+  findFlowEntryByCorrelationKeyInTab: vi.fn(),
   findHttpMessagesOfFlow: vi.fn(),
 }));
 
@@ -33,8 +34,8 @@ vi.mock("@/common/services/http-store.ts", () => ({
 }));
 
 vi.mock("@/common/services/saml-store.ts", () => ({
-  deleteSamlTraces: vi.fn(),
-  findSamlTraces: vi.fn(),
+  deleteSamlTracesByFlowId: vi.fn(),
+  findSamlTracesByFlowId: vi.fn(),
 }));
 
 vi.mock("@/common/utils/chrome-debugger.ts", () => ({
@@ -44,12 +45,13 @@ vi.mock("@/common/utils/chrome-debugger.ts", () => ({
 beforeEach(() => {
   vi.resetAllMocks();
 
-  vi.mocked(findSamlTraces).mockResolvedValue([]);
+  vi.mocked(findFlowEntriesByTabId).mockResolvedValue([]);
   vi.mocked(getCaptureSession).mockResolvedValue(undefined);
-  vi.mocked(findFlowEntryById).mockResolvedValue(undefined);
+  vi.mocked(findSamlTracesByFlowId).mockResolvedValue([]);
   vi.mocked(isAttached).mockResolvedValue(false);
+  vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(makeFlowEntry());
   vi.mocked(findHttpMessagesOfFlow).mockResolvedValue([]);
-  vi.mocked(deleteSamlTraces).mockResolvedValue(undefined);
+  vi.mocked(deleteSamlTracesByFlowId).mockResolvedValue(undefined);
   vi.mocked(deleteHttpMessages).mockResolvedValue(undefined);
 });
 
@@ -97,21 +99,23 @@ function makeCaptureSession(overrides: Partial<CaptureSession> = {}): CaptureSes
 //
 
 describe("getSessionSummaries", () => {
-  it("returns an empty array when no traces exist", async () => {
+  it("returns an empty array when no flows exist", async () => {
     expect(await getSessionSummaries(1)).toEqual([]);
   });
 
-  it("builds one summary per flow, newest flow first", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([
-      makeSamlTrace({ id: "trace-1", flowId: "flow-1", step: 2, action: "first action" }),
-      makeSamlTrace({ id: "trace-2", flowId: "flow-1", step: 3, action: "second action" }),
-      makeSamlTrace({ id: "trace-3", flowId: "flow-2", step: 2, action: "other action" }),
+  it("builds one summary per flow in the given order", async () => {
+    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([
+      makeFlowEntry({ id: "flow-2", correlationKey: "corr-2" }),
+      makeFlowEntry({ id: "flow-1", correlationKey: "corr-1" }),
     ]);
     vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession());
-    vi.mocked(findFlowEntryById).mockImplementation(async (id) =>
-      id === "flow-1"
-        ? makeFlowEntry({ id: "flow-1", correlationKey: "corr-1" })
-        : makeFlowEntry({ id: "flow-2", correlationKey: "corr-2" }),
+    vi.mocked(findSamlTracesByFlowId).mockImplementation(async (flowId) =>
+      flowId === "flow-1"
+        ? [
+            makeSamlTrace({ id: "trace-1", flowId: "flow-1", step: 2, action: "first action" }),
+            makeSamlTrace({ id: "trace-2", flowId: "flow-1", step: 3, action: "second action" }),
+          ]
+        : [makeSamlTrace({ id: "trace-3", flowId: "flow-2", step: 2, action: "other action" })],
     );
 
     const result = await getSessionSummaries(1);
@@ -124,11 +128,11 @@ describe("getSessionSummaries", () => {
   });
 
   it("derives imported from the capture session", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
+    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
     vi.mocked(getCaptureSession).mockResolvedValue(
       makeCaptureSession({ imported: true, importedAt: "2026-01-01T00:00:00Z" }),
     );
-    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
 
     const result = await getSessionSummaries(1);
 
@@ -136,71 +140,63 @@ describe("getSessionSummaries", () => {
   });
 
   it("sets capturing when the capture session is ongoing and the debugger is attached", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
+    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
     vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession({ endedAt: undefined }));
-    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
     vi.mocked(isAttached).mockResolvedValue(true);
 
     expect(await getSessionSummaries(1)).toMatchObject([{ capturing: true }]);
   });
 
   it("does not set capturing when the capture session has ended", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
+    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
     vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession());
-    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
     vi.mocked(isAttached).mockResolvedValue(true);
 
     expect(await getSessionSummaries(1)).toMatchObject([{ capturing: false }]);
   });
 
   it("does not set capturing when the debugger is not attached", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
+    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
     vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession({ endedAt: undefined }));
-    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
     vi.mocked(isAttached).mockResolvedValue(false);
 
     expect(await getSessionSummaries(1)).toMatchObject([{ capturing: false }]);
   });
 
-  it("skips traces without a flow entry with a warning", async () => {
-    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({ flowId: "flow-x" })]);
-
-    expect(await getSessionSummaries(1)).toEqual([]);
-    expect(consoleWarn).toHaveBeenCalledOnce();
-  });
-
-  it("propagates an error from the trace store", async () => {
-    const error = new Error("trace store error");
-    vi.mocked(findSamlTraces).mockResolvedValue(error);
+  it("propagates an error from the flow query", async () => {
+    const error = new Error("flow query error");
+    vi.mocked(findFlowEntriesByTabId).mockResolvedValue(error);
 
     expect(await getSessionSummaries(1)).toBe(error);
   });
 
   it("propagates an error from the capture session query", async () => {
     const error = new Error("capture query error");
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
-    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
     vi.mocked(getCaptureSession).mockResolvedValue(error);
 
     expect(await getSessionSummaries(1)).toBe(error);
   });
 
-  it("propagates an error from the flow store", async () => {
-    const error = new Error("flow store error");
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
-    vi.mocked(findFlowEntryById).mockResolvedValue(error);
+  it("propagates an error from the trace store", async () => {
+    const error = new Error("trace store error");
+    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
+    vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession());
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue(error);
 
     expect(await getSessionSummaries(1)).toBe(error);
   });
 
   it("skips a flow whose capture session is missing with a warning", async () => {
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace({})]);
-    vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
+    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
 
     expect(await getSessionSummaries(1)).toEqual([]);
     expect(consoleWarn).toHaveBeenCalledOnce();
+    expect(findSamlTracesByFlowId).not.toHaveBeenCalled();
   });
 
   it("propagates an error from the debugger", async () => {
@@ -217,12 +213,31 @@ describe("deleteSession", () => {
     vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(httpMessages);
 
     expect(await deleteSession(1, "corr-1")).toBeUndefined();
-    expect(findHttpMessagesOfFlow).toHaveBeenCalledWith(1, "corr-1");
-    expect(deleteSamlTraces).toHaveBeenCalledWith(1, "corr-1");
+    expect(findFlowEntryByCorrelationKeyInTab).toHaveBeenCalledWith(1, "corr-1");
+    expect(findHttpMessagesOfFlow).toHaveBeenCalledWith("flow-1");
+    expect(deleteSamlTracesByFlowId).toHaveBeenCalledWith("flow-1");
     expect(deleteHttpMessages).toHaveBeenCalledWith(httpMessages);
-    expect(vi.mocked(deleteSamlTraces).mock.invocationCallOrder[0]).toBeLessThan(
+    expect(vi.mocked(deleteSamlTracesByFlowId).mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(deleteHttpMessages).mock.invocationCallOrder[0]!,
     );
+  });
+
+  it("does nothing with a warning when no flow has the session ID", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(undefined);
+
+    expect(await deleteSession(1, "corr-1")).toBeUndefined();
+    expect(consoleWarn).toHaveBeenCalledOnce();
+    expect(deleteSamlTracesByFlowId).not.toHaveBeenCalled();
+    expect(deleteHttpMessages).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the flow cannot be found", async () => {
+    const error = new Error("flow query error");
+    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(error);
+
+    expect(await deleteSession(1, "corr-1")).toBe(error);
+    expect(deleteSamlTracesByFlowId).not.toHaveBeenCalled();
   });
 
   it("returns an error when the HTTP messages cannot be found", async () => {
@@ -230,13 +245,13 @@ describe("deleteSession", () => {
     vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(error);
 
     expect(await deleteSession(1, "corr-1")).toBe(error);
-    expect(deleteSamlTraces).not.toHaveBeenCalled();
+    expect(deleteSamlTracesByFlowId).not.toHaveBeenCalled();
     expect(deleteHttpMessages).not.toHaveBeenCalled();
   });
 
   it("returns an error when the trace deletion fails", async () => {
     const error = new Error("saml delete error");
-    vi.mocked(deleteSamlTraces).mockResolvedValue(error);
+    vi.mocked(deleteSamlTracesByFlowId).mockResolvedValue(error);
 
     expect(await deleteSession(1, "corr-1")).toBe(error);
     expect(deleteHttpMessages).not.toHaveBeenCalled();

--- a/src/common/services/session-manager.ts
+++ b/src/common/services/session-manager.ts
@@ -11,6 +11,7 @@ import {
   findFlowEntryByCorrelationKeyInTab,
   findHttpMessagesOfFlow,
 } from "@/common/services/flow-query.ts";
+import { deleteFlowEntry } from "@/common/services/flow-store.ts";
 import { deleteHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTracesByFlowId, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 import { summarizeSamlFlow } from "@/common/services/saml-summarizer.ts";
@@ -92,6 +93,11 @@ export async function deleteSession(tabId: number, sessionId: string): Promise<v
   const samlDeleteError = await deleteSamlTracesByFlowId(flowEntry.id);
   if (samlDeleteError) {
     return samlDeleteError;
+  }
+
+  const flowDeleteError = await deleteFlowEntry(flowEntry);
+  if (flowDeleteError) {
+    return flowDeleteError;
   }
 
   const httpDeleteError = await deleteHttpMessages(httpMessages);

--- a/src/common/services/session-manager.ts
+++ b/src/common/services/session-manager.ts
@@ -4,13 +4,15 @@
  */
 
 import { type CaptureSession } from "@/common/models/capture-session.ts";
-import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { type SessionSummary, debugSessionSummary } from "@/common/models/session-summary.ts";
 import { getCaptureSession } from "@/common/services/capture-query.ts";
-import { findFlowEntryById } from "@/common/services/flow-store.ts";
-import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import {
+  findFlowEntriesByTabId,
+  findFlowEntryByCorrelationKeyInTab,
+  findHttpMessagesOfFlow,
+} from "@/common/services/flow-query.ts";
 import { deleteHttpMessages } from "@/common/services/http-store.ts";
-import { deleteSamlTraces, findSamlTraces } from "@/common/services/saml-store.ts";
+import { deleteSamlTracesByFlowId, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 import { summarizeSamlFlow } from "@/common/services/saml-summarizer.ts";
 import { isAttached } from "@/common/utils/chrome-debugger.ts";
 
@@ -30,27 +32,24 @@ export async function getSessionSummaries(tabId: number): Promise<SessionSummary
     return attached;
   }
 
-  const samlTracesByFlowId = await findSamlTracesGroupedByFlowId(tabId);
-  if (samlTracesByFlowId instanceof Error) {
-    return samlTracesByFlowId;
+  const flowEntries = await findFlowEntriesByTabId(tabId);
+  if (flowEntries instanceof Error) {
+    return flowEntries;
   }
 
   const summaries: SessionSummary[] = [];
-  for (const [flowId, samlTraces] of samlTracesByFlowId) {
-    const flowEntry = await findFlowEntryById(flowId);
-    if (flowEntry instanceof Error) {
-      return flowEntry;
-    } else if (flowEntry === undefined) {
-      console.warn("No flow entry for the traces:", { flowId });
-      continue;
-    }
-
+  for (const flowEntry of flowEntries) {
     const captureSession = await getCaptureSession(flowEntry.captureSessionId);
     if (captureSession instanceof Error) {
       return captureSession;
     } else if (captureSession === undefined) {
-      console.warn("No capture session for the flow:", { flowId });
+      console.warn("No capture session for the flow:", { flowId: flowEntry.id });
       continue;
+    }
+
+    const samlTraces = await findSamlTracesByFlowId(flowEntry.id);
+    if (samlTraces instanceof Error) {
+      return samlTraces;
     }
 
     const summary = {
@@ -65,24 +64,6 @@ export async function getSessionSummaries(tabId: number): Promise<SessionSummary
   return summaries;
 }
 
-async function findSamlTracesGroupedByFlowId(
-  tabId: number,
-): Promise<Map<string, SamlTrace[]> | Error> {
-  const samlTraces = await findSamlTraces(tabId);
-  if (samlTraces instanceof Error) {
-    return samlTraces;
-  }
-
-  // TODO: Rewrite with Map.groupBy after raising the TypeScript target to ES2024 or later
-  const samlTracesByFlowId = samlTraces.reduce((acc, trace) => {
-    const current = acc.get(trace.flowId) ?? [];
-    acc.set(trace.flowId, [...current, trace]);
-    return acc;
-  }, new Map<string, SamlTrace[]>());
-
-  return new Map([...samlTracesByFlowId.entries()].toSorted(([a], [b]) => (a < b ? 1 : -1)));
-}
-
 function isOngoing(captureSession: CaptureSession): boolean {
   return !captureSession.imported && captureSession.endedAt === undefined;
 }
@@ -95,12 +76,20 @@ function isOngoing(captureSession: CaptureSession): boolean {
  * @returns void on success, or an Error
  */
 export async function deleteSession(tabId: number, sessionId: string): Promise<void | Error> {
-  const httpMessages = await findHttpMessagesOfFlow(tabId, sessionId);
+  const flowEntry = await findFlowEntryByCorrelationKeyInTab(tabId, sessionId);
+  if (flowEntry instanceof Error) {
+    return flowEntry;
+  } else if (flowEntry === undefined) {
+    console.warn("No flow to delete:", { tabId, sessionId });
+    return;
+  }
+
+  const httpMessages = await findHttpMessagesOfFlow(flowEntry.id);
   if (httpMessages instanceof Error) {
     return httpMessages;
   }
 
-  const samlDeleteError = await deleteSamlTraces(tabId, sessionId);
+  const samlDeleteError = await deleteSamlTracesByFlowId(flowEntry.id);
   if (samlDeleteError) {
     return samlDeleteError;
   }

--- a/src/common/utils/chrome-storage.ts
+++ b/src/common/utils/chrome-storage.ts
@@ -11,17 +11,6 @@ export async function setSessionStorageItem(key: string, value: unknown): Promis
   }
 }
 
-export async function getSessionStorageItemValue(
-  key: string,
-): Promise<unknown | undefined | Error> {
-  try {
-    const item = await chrome.storage.session.get(key);
-    return item[key];
-  } catch (err) {
-    return new Error("Failed to get item value from session storage", { cause: err });
-  }
-}
-
 export async function getSessionStorageItems(
   keys: string[],
 ): Promise<Record<string, unknown> | Error> {
@@ -41,17 +30,6 @@ export async function getAllSessionStorageItems(): Promise<Record<string, unknow
   }
 }
 
-export async function getSessionStorageItemsByKeyPrefix(
-  keyPrefix: string,
-): Promise<Record<string, unknown> | Error> {
-  const keys = await getSessionStorageKeysByPrefix(keyPrefix);
-  if (keys instanceof Error) {
-    return keys;
-  }
-
-  return await getSessionStorageItems(keys);
-}
-
 export async function removeSessionStorageItems(keys: string[]): Promise<void | Error> {
   try {
     await chrome.storage.session.remove(keys);
@@ -60,31 +38,11 @@ export async function removeSessionStorageItems(keys: string[]): Promise<void | 
   }
 }
 
-export async function removeSessionStorageItemsByKeyPrefix(
-  keyPrefix: string,
-): Promise<void | Error> {
-  const keys = await getSessionStorageKeysByPrefix(keyPrefix);
-  if (keys instanceof Error) {
-    return keys;
-  }
-
-  return await removeSessionStorageItems(keys);
-}
-
 export async function getAllSessionStorageKeys(): Promise<string[] | Error> {
   try {
     return await chrome.storage.session.getKeys();
   } catch (err) {
     return new Error("Failed to get all keys from session storage", { cause: err });
-  }
-}
-
-async function getSessionStorageKeysByPrefix(prefix: string): Promise<string[] | Error> {
-  try {
-    const allKeys = await chrome.storage.session.getKeys();
-    return allKeys.filter((k) => k.startsWith(prefix));
-  } catch (err) {
-    return new Error("Failed to get keys from session storage", { cause: err });
   }
 }
 

--- a/src/report-page/app-builders.test.ts
+++ b/src/report-page/app-builders.test.ts
@@ -48,7 +48,6 @@ function makeSamlTrace(id: string, step: SamlTrace["step"], httpMessageId: strin
     httpMessageId,
     observedAt: "2026-01-01T00:00:00Z",
     serverHostname: "sp.example.com",
-    sessionId: "corr-1",
     action: "test action",
     step,
     type: "UnauthenticatedResourceRequest",

--- a/src/report-page/app-builders.ts
+++ b/src/report-page/app-builders.ts
@@ -6,13 +6,15 @@
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { getCaptureSession } from "@/common/services/capture-query.ts";
-import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
-import { findFlowEntryById } from "@/common/services/flow-store.ts";
+import {
+  findFlowEntryByCorrelationKeyInTab,
+  findHttpMessagesOfFlow,
+} from "@/common/services/flow-query.ts";
 import {
   extractSamlAuthnRequestXml,
   extractSamlResponseXml,
 } from "@/common/services/saml-detector.ts";
-import { findSamlTraces } from "@/common/services/saml-store.ts";
+import { findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 import { type FlowData } from "@/report-page/common/types.ts";
 
 export async function loadFlowData(
@@ -29,22 +31,11 @@ export async function loadFlowData(
     }
   }
 
-  const tabSamlTraces = await findSamlTraces(tabId);
-  if (tabSamlTraces instanceof Error) {
-    return tabSamlTraces;
-  }
-
-  const samlTraces = tabSamlTraces.filter((t) => t.sessionId === sessionId);
-  const firstSamlTrace = samlTraces[0];
-  if (firstSamlTrace === undefined) {
-    return new Error(`No SAML traces: tabId=${tabId}, sessionId=${sessionId}`);
-  }
-
-  const flowEntry = await findFlowEntryById(firstSamlTrace.flowId);
+  const flowEntry = await findFlowEntryByCorrelationKeyInTab(tabId, sessionId);
   if (flowEntry instanceof Error) {
     return flowEntry;
   } else if (flowEntry === undefined) {
-    return new Error(`No flow entry: ${firstSamlTrace.flowId}`);
+    return new Error("Flow not found");
   }
 
   const captureSession = await getCaptureSession(flowEntry.captureSessionId);
@@ -54,7 +45,12 @@ export async function loadFlowData(
     return new Error(`No capture session: ${flowEntry.captureSessionId}`);
   }
 
-  const httpMessages = await findHttpMessagesOfFlow(tabId, sessionId);
+  const samlTraces = await findSamlTracesByFlowId(flowEntry.id);
+  if (samlTraces instanceof Error) {
+    return samlTraces;
+  }
+
+  const httpMessages = await findHttpMessagesOfFlow(flowEntry.id);
   if (httpMessages instanceof Error) {
     return httpMessages;
   }

--- a/src/report-page/dev/sample-flow.ts
+++ b/src/report-page/dev/sample-flow.ts
@@ -35,7 +35,8 @@ export async function buildSampleFlowData(): Promise<FlowData> {
   const sample = new URLSearchParams(window.location.search).get("sample");
 
   const allHttpMessages = await buildSampleHttpMessages(sample);
-  const allSamlTraces = await buildSampleSamlTraces(allHttpMessages);
+  const { samlTraces: allSamlTraces, correlationKey } =
+    await buildSampleSamlTraces(allHttpMessages);
 
   const httpMessages = selectSampleHttpMessages(sample, allHttpMessages);
   const httpMessageIds = new Set(httpMessages.map((m) => m.id));
@@ -45,7 +46,7 @@ export async function buildSampleFlowData(): Promise<FlowData> {
     id: sampleFlowId,
     captureSessionId: sampleCaptureSessionId,
     protocol: "saml",
-    correlationKey: allSamlTraces[0]?.sessionId ?? "",
+    correlationKey,
   };
 
   const captureSession: CaptureSession = {
@@ -217,8 +218,35 @@ function selectSampleHttpMessages(
   return allHttpMessages;
 }
 
-async function buildSampleSamlTraces(httpMessages: HttpMessage[]): Promise<SamlTrace[]> {
+async function buildSampleSamlTraces(
+  httpMessages: HttpMessage[],
+): Promise<{ samlTraces: SamlTrace[]; correlationKey: string }> {
+  const detections = await detectSampleSamlSteps(httpMessages);
+  const correlationKey = detections[0]?.detection.correlationKey ?? "";
+
   const samlTraces: SamlTrace[] = [];
+  for (const { detection, httpMessage, pairedHttpRequest } of detections) {
+    if (detection.step === 2 && pairedHttpRequest !== undefined) {
+      pushSamlTrace(
+        samlTraces,
+        { step: 1, correlationKey: detection.correlationKey },
+        pairedHttpRequest,
+      );
+    }
+    pushSamlTrace(samlTraces, detection, httpMessage);
+  }
+
+  return { samlTraces, correlationKey };
+}
+
+type SampleSamlDetection = {
+  detection: SamlDetection;
+  httpMessage: HttpMessage;
+  pairedHttpRequest?: HttpRequest;
+};
+
+async function detectSampleSamlSteps(httpMessages: HttpMessage[]): Promise<SampleSamlDetection[]> {
+  const detections: SampleSamlDetection[] = [];
 
   for (const httpMessage of httpMessages) {
     const pairedHttpRequest =
@@ -234,17 +262,10 @@ async function buildSampleSamlTraces(httpMessages: HttpMessage[]): Promise<SamlT
       continue;
     }
 
-    if (detection.step === 2 && pairedHttpRequest !== undefined) {
-      pushSamlTrace(
-        samlTraces,
-        { step: 1, correlationKey: detection.correlationKey },
-        pairedHttpRequest,
-      );
-    }
-    pushSamlTrace(samlTraces, detection, httpMessage);
+    detections.push({ detection, httpMessage, pairedHttpRequest });
   }
 
-  return samlTraces;
+  return detections;
 }
 
 async function detectSamlStep(

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -114,16 +114,7 @@ async function onStopMonitoring(tabId: number): Promise<void | Error> {
 }
 
 async function onGetSessionSummaries(tabId: number): Promise<SessionSummary[] | Error> {
-  const summaries = await getSessionSummaries(tabId);
-  if (summaries instanceof Error) {
-    return summaries;
-  }
-
-  return summaries.map((summary) => ({
-    ...summary,
-    // for backward compatibility
-    source: summary.imported ? "imported" : "captured",
-  }));
+  return await getSessionSummaries(tabId);
 }
 
 async function onRemoveSession(tabId: number, sessionId: string): Promise<void | Error> {


### PR DESCRIPTION
- **Read flow data by flow ID instead of tab and session ID**
- **Delete flows and drop session ID from traces**
- **Remove unused prefix-based storage functions**
- **Remove backward compat source field from summaries**
