### PR TITLE
Tidy up service worker code

### DIFF
--- a/src/common/services/event-store.test.ts
+++ b/src/common/services/event-store.test.ts
@@ -6,7 +6,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   newCaptureStartedRecord,
-  newCaptureStoppedRecord,
   newDebuggerAttachedRecord,
   newDebuggerDetachedRecord,
   newWatchStartedRecord,
@@ -16,11 +15,7 @@ import {
   getSessionStorageItems,
   setSessionStorageItem,
 } from "@/common/utils/chrome-storage.ts";
-import {
-  findAllEventRecords,
-  findEventRecordKeyFieldsByTypes,
-  saveEventRecord,
-} from "./event-store.ts";
+import { findAllEventRecords, saveEventRecord } from "./event-store.ts";
 
 vi.mock("@/common/utils/chrome-storage.ts", () => ({
   getAllSessionStorageKeys: vi.fn(),
@@ -77,76 +72,6 @@ describe("saveEventRecord", () => {
     const result = await saveEventRecord(newCaptureStartedRecord());
 
     expect(result).toBe(error);
-  });
-});
-
-describe("findEventRecordKeyFieldsByTypes", () => {
-  it("returns the key fields of the given types sorted by ID", async () => {
-    const first = newCaptureStartedRecord();
-    const second = newWatchStartedRecord(1);
-    const third = newCaptureStoppedRecord();
-    vi.mocked(getAllSessionStorageKeys).mockResolvedValue([
-      `{"id":"${third.id}","kind":"event","type":"CaptureStopped"}`,
-      `{"id":"${second.id}","kind":"event","type":"WatchStarted","tabId":1}`,
-      `{"id":"${first.id}","kind":"event","type":"CaptureStarted"}`,
-    ]);
-
-    const result = await findEventRecordKeyFieldsByTypes(["CaptureStarted", "CaptureStopped"]);
-
-    expect(result).toEqual([
-      { id: first.id, kind: "event", type: "CaptureStarted" },
-      { id: third.id, kind: "event", type: "CaptureStopped" },
-    ]);
-  });
-
-  it("keeps the tab ID of tab-scoped records", async () => {
-    const record = newWatchStartedRecord(42);
-    vi.mocked(getAllSessionStorageKeys).mockResolvedValue([
-      `{"id":"${record.id}","kind":"event","type":"WatchStarted","tabId":42}`,
-    ]);
-
-    expect(await findEventRecordKeyFieldsByTypes(["WatchStarted"])).toEqual([
-      { id: record.id, kind: "event", type: "WatchStarted", tabId: 42 },
-    ]);
-  });
-
-  it("ignores keys that are not event record keys", async () => {
-    const record = newCaptureStartedRecord();
-    const key = `{"id":"${record.id}","kind":"event","type":"CaptureStarted"}`;
-    vi.mocked(getAllSessionStorageKeys).mockResolvedValue([
-      "not-a-json-key",
-      '{"id":"x","kind":"event","type":"TabClosed"}',
-      '{"id":"x","kind":"httpMessage","type":"CaptureStarted"}',
-      key,
-    ]);
-
-    expect(await findEventRecordKeyFieldsByTypes(["CaptureStarted"])).toEqual([
-      { id: record.id, kind: "event", type: "CaptureStarted" },
-    ]);
-  });
-
-  it("returns an empty array when no key has the given types", async () => {
-    const record = newWatchStartedRecord(1);
-    vi.mocked(getAllSessionStorageKeys).mockResolvedValue([
-      `{"id":"${record.id}","kind":"event","type":"WatchStarted","tabId":1}`,
-    ]);
-
-    expect(await findEventRecordKeyFieldsByTypes(["CaptureStarted"])).toEqual([]);
-  });
-
-  it("does not read the stored values", async () => {
-    vi.mocked(getAllSessionStorageKeys).mockResolvedValue([]);
-
-    await findEventRecordKeyFieldsByTypes(["CaptureStarted"]);
-
-    expect(getSessionStorageItems).not.toHaveBeenCalled();
-  });
-
-  it("propagates an error from the key retrieval", async () => {
-    const error = new Error("storage failed");
-    vi.mocked(getAllSessionStorageKeys).mockResolvedValue(error);
-
-    expect(await findEventRecordKeyFieldsByTypes(["CaptureStarted"])).toBe(error);
   });
 });
 

--- a/src/common/services/event-store.ts
+++ b/src/common/services/event-store.ts
@@ -20,21 +20,6 @@ export async function saveEventRecord(record: EventRecord): Promise<void | Error
   return await setSessionStorageItem(makeEventRecordKey(record), record);
 }
 
-export async function findEventRecordKeyFieldsByTypes(
-  eventRecordTypes: EventRecordType[],
-): Promise<EventRecordKeyFields[] | Error> {
-  const allKeys = await getAllSessionStorageKeys();
-  if (allKeys instanceof Error) {
-    return allKeys;
-  }
-
-  return allKeys
-    .map(parseEventRecordKey)
-    .filter((f) => f !== undefined)
-    .filter((f) => eventRecordTypes.includes(f.type))
-    .toSorted((a, b) => (a.id < b.id ? -1 : 1));
-}
-
 export async function findAllEventRecords(): Promise<EventRecord[] | Error> {
   const allKeys = await getAllSessionStorageKeys();
   if (allKeys instanceof Error) {
@@ -60,7 +45,7 @@ export async function findAllEventRecords(): Promise<EventRecord[] | Error> {
 
 const eventRecordKind = "event";
 
-export type EventRecordKeyFields = {
+type EventRecordKeyFields = {
   id: string;
   kind: typeof eventRecordKind;
   type: EventRecordType;

--- a/src/common/services/flow-query.test.ts
+++ b/src/common/services/flow-query.test.ts
@@ -9,7 +9,7 @@ import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { findFlowEntryById } from "@/common/services/flow-store.ts";
 import { findHttpMessagesByIds } from "@/common/services/http-store.ts";
-import { findSamlTraces, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
+import { findSamlTracesByFlowId, findSamlTracesByTabId } from "@/common/services/saml-store.ts";
 import {
   findFlowEntriesByTabId,
   findFlowEntryByCorrelationKeyInTab,
@@ -25,8 +25,8 @@ vi.mock("@/common/services/http-store.ts", () => ({
 }));
 
 vi.mock("@/common/services/saml-store.ts", () => ({
-  findSamlTraces: vi.fn(),
   findSamlTracesByFlowId: vi.fn(),
+  findSamlTracesByTabId: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -142,7 +142,7 @@ describe("findFlowEntriesByTabId", () => {
   it("returns the flows of the traces in the tab, newest first", async () => {
     const flow1 = makeFlowEntry("flow-1");
     const flow2 = makeFlowEntry("flow-2");
-    vi.mocked(findSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTracesByTabId).mockResolvedValue([
       makeSamlTrace("msg-1", "flow-1"),
       makeSamlTrace("msg-2", "flow-1"),
       makeSamlTrace("msg-3", "flow-2"),
@@ -151,13 +151,13 @@ describe("findFlowEntriesByTabId", () => {
 
     const result = await findFlowEntriesByTabId(1);
 
-    expect(findSamlTraces).toHaveBeenCalledWith(1);
+    expect(findSamlTracesByTabId).toHaveBeenCalledWith(1);
     expect(findFlowEntryById).toHaveBeenCalledTimes(2);
     expect(result).toEqual([flow2, flow1]);
   });
 
   it("returns an empty array when the tab has no traces", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([]);
+    vi.mocked(findSamlTracesByTabId).mockResolvedValue([]);
 
     expect(await findFlowEntriesByTabId(1)).toEqual([]);
     expect(findFlowEntryById).not.toHaveBeenCalled();
@@ -166,7 +166,7 @@ describe("findFlowEntriesByTabId", () => {
   it("skips traces without a flow entry with a warning", async () => {
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const flow1 = makeFlowEntry("flow-1");
-    vi.mocked(findSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTracesByTabId).mockResolvedValue([
       makeSamlTrace("msg-1", "flow-1"),
       makeSamlTrace("msg-2", "flow-x"),
     ]);
@@ -178,7 +178,7 @@ describe("findFlowEntriesByTabId", () => {
 
   it("returns an error when the traces cannot be found", async () => {
     const error = new Error("saml store error");
-    vi.mocked(findSamlTraces).mockResolvedValue(error);
+    vi.mocked(findSamlTracesByTabId).mockResolvedValue(error);
 
     expect(await findFlowEntriesByTabId(1)).toBe(error);
     expect(findFlowEntryById).not.toHaveBeenCalled();
@@ -186,7 +186,7 @@ describe("findFlowEntriesByTabId", () => {
 
   it("returns an error when a flow cannot be found", async () => {
     const error = new Error("flow store error");
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-1")]);
+    vi.mocked(findSamlTracesByTabId).mockResolvedValue([makeSamlTrace("msg-1")]);
     vi.mocked(findFlowEntryById).mockResolvedValue(error);
 
     expect(await findFlowEntriesByTabId(1)).toBe(error);
@@ -196,7 +196,7 @@ describe("findFlowEntriesByTabId", () => {
 describe("findFlowEntryByCorrelationKeyInTab", () => {
   it("returns the flow with the correlation key among the flows of the tab", async () => {
     const flow2 = makeFlowEntry("flow-2");
-    vi.mocked(findSamlTraces).mockResolvedValue([
+    vi.mocked(findSamlTracesByTabId).mockResolvedValue([
       makeSamlTrace("msg-1", "flow-1"),
       makeSamlTrace("msg-2", "flow-2"),
     ]);
@@ -206,7 +206,7 @@ describe("findFlowEntryByCorrelationKeyInTab", () => {
   });
 
   it("returns undefined when no flow of the tab has the correlation key", async () => {
-    vi.mocked(findSamlTraces).mockResolvedValue([makeSamlTrace("msg-1", "flow-1")]);
+    vi.mocked(findSamlTracesByTabId).mockResolvedValue([makeSamlTrace("msg-1", "flow-1")]);
     mockFlowStore(makeFlowEntry("flow-1"));
 
     expect(await findFlowEntryByCorrelationKeyInTab(1, "corr-x")).toBeUndefined();
@@ -214,7 +214,7 @@ describe("findFlowEntryByCorrelationKeyInTab", () => {
 
   it("returns an error when the flows cannot be found", async () => {
     const error = new Error("saml store error");
-    vi.mocked(findSamlTraces).mockResolvedValue(error);
+    vi.mocked(findSamlTracesByTabId).mockResolvedValue(error);
 
     expect(await findFlowEntryByCorrelationKeyInTab(1, "corr-flow-1")).toBe(error);
   });

--- a/src/common/services/flow-query.ts
+++ b/src/common/services/flow-query.ts
@@ -7,7 +7,7 @@ import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { findFlowEntryById } from "@/common/services/flow-store.ts";
 import { findHttpMessagesByIds } from "@/common/services/http-store.ts";
-import { findSamlTraces, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
+import { findSamlTracesByFlowId, findSamlTracesByTabId } from "@/common/services/saml-store.ts";
 
 export async function findHttpMessagesOfFlow(flowId: string): Promise<HttpMessage[] | Error> {
   const samlTraces = await findSamlTracesByFlowId(flowId);
@@ -37,7 +37,7 @@ export async function findHttpMessagesOfFlow(flowId: string): Promise<HttpMessag
 }
 
 export async function findFlowEntriesByTabId(tabId: number): Promise<FlowEntry[] | Error> {
-  const samlTraces = await findSamlTraces(tabId);
+  const samlTraces = await findSamlTracesByTabId(tabId);
   if (samlTraces instanceof Error) {
     return samlTraces;
   }

--- a/src/common/services/saml-recorder.test.ts
+++ b/src/common/services/saml-recorder.test.ts
@@ -77,7 +77,7 @@ describe("recordSamlTrace", () => {
     const result = await recordSamlTrace(
       "cs-1",
       1,
-      { step: 2, correlationKey: "authn-req-1" },
+      { step: 6, correlationKey: "authn-req-1" },
       makeResponse(),
     );
 
@@ -190,7 +190,7 @@ describe("recordSamlTrace", () => {
     const result = await recordSamlTrace(
       "cs-1",
       1,
-      { step: 2, correlationKey: "authn-req-1" },
+      { step: 6, correlationKey: "authn-req-1" },
       makeResponse(),
     );
 

--- a/src/common/services/saml-store.test.ts
+++ b/src/common/services/saml-store.test.ts
@@ -13,8 +13,8 @@ import {
 } from "@/common/utils/chrome-storage.ts";
 import {
   deleteSamlTracesByFlowId,
-  findSamlTraces,
   findSamlTracesByFlowId,
+  findSamlTracesByTabId,
   saveSamlTrace,
 } from "./saml-store.ts";
 
@@ -73,18 +73,18 @@ describe("saveSamlTrace", () => {
     await saveSamlTrace(makeTrace({ id: "trace-1", step: 2 }), 1);
     await saveSamlTrace(makeTrace({ id: "trace-2", step: 2 }), 1);
 
-    expect(await findSamlTraces(1)).toHaveLength(2);
+    expect(await findSamlTracesByTabId(1)).toHaveLength(2);
   });
 });
 
-describe("findSamlTraces", () => {
+describe("findSamlTracesByTabId", () => {
   it("returns the traces of the tab in id order", async () => {
     await saveSamlTrace(makeTrace({ id: "trace-2" }), 1);
     await saveSamlTrace(makeTrace({ id: "trace-1" }), 1);
     await saveSamlTrace(makeTrace({ id: "trace-3" }), 2);
     storage["other-key"] = { some: "value" };
 
-    const result = await findSamlTraces(1);
+    const result = await findSamlTracesByTabId(1);
 
     expect(result).not.toBeInstanceOf(Error);
     expect((result as SamlTrace[]).map((t) => t.id)).toEqual(["trace-1", "trace-2"]);
@@ -95,7 +95,7 @@ describe("findSamlTraces", () => {
     storage['{"id":"trace-1","kind":"trace","tabId":1,"flowId":"flow-1"}'] = { broken: true };
     await saveSamlTrace(makeTrace({ id: "trace-2" }), 1);
 
-    const result = await findSamlTraces(1);
+    const result = await findSamlTracesByTabId(1);
 
     expect((result as SamlTrace[]).map((t) => t.id)).toEqual(["trace-2"]);
     expect(consoleWarn).toHaveBeenCalledOnce();
@@ -105,7 +105,7 @@ describe("findSamlTraces", () => {
     const error = new Error("storage error");
     vi.mocked(getAllSessionStorageKeys).mockResolvedValue(error);
 
-    expect(await findSamlTraces(1)).toBe(error);
+    expect(await findSamlTracesByTabId(1)).toBe(error);
   });
 });
 
@@ -150,8 +150,8 @@ describe("deleteSamlTracesByFlowId", () => {
 
     expect(result).toBeUndefined();
     expect(getSessionStorageItems).not.toHaveBeenCalled();
-    expect(((await findSamlTraces(1)) as SamlTrace[]).map((t) => t.id)).toEqual(["trace-2"]);
-    expect(await findSamlTraces(2)).toEqual([]);
+    expect(((await findSamlTracesByTabId(1)) as SamlTrace[]).map((t) => t.id)).toEqual(["trace-2"]);
+    expect(await findSamlTracesByTabId(2)).toEqual([]);
   });
 
   it("propagates an error from the key retrieval", async () => {

--- a/src/common/services/saml-store.ts
+++ b/src/common/services/saml-store.ts
@@ -25,7 +25,7 @@ export async function deleteSamlTracesByFlowId(flowId: string): Promise<void | E
   return await removeSessionStorageItems(keys);
 }
 
-export async function findSamlTraces(tabId: number): Promise<SamlTrace[] | Error> {
+export async function findSamlTracesByTabId(tabId: number): Promise<SamlTrace[] | Error> {
   return await findSamlTracesBy((k) => k.tabId === tabId);
 }
 

--- a/src/service-worker/capture-manager.test.ts
+++ b/src/service-worker/capture-manager.test.ts
@@ -5,10 +5,12 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  type EventRecordKeyFields,
-  findEventRecordKeyFieldsByTypes,
-  saveEventRecord,
-} from "@/common/services/event-store.ts";
+  type EventRecord,
+  newCaptureStartedRecord,
+  newCaptureStoppedRecord,
+  newWatchStartedRecord,
+} from "@/common/models/event-record.ts";
+import { findAllEventRecords, saveEventRecord } from "@/common/services/event-store.ts";
 import {
   getWatchedTabIds,
   registerWatchStopHandler,
@@ -24,7 +26,7 @@ import {
 } from "./capture-manager.ts";
 
 vi.mock("@/common/services/event-store.ts", () => ({
-  findEventRecordKeyFieldsByTypes: vi.fn(),
+  findAllEventRecords: vi.fn(),
   saveEventRecord: vi.fn(),
 }));
 
@@ -47,7 +49,7 @@ beforeEach(() => {
   vi.spyOn(console, "info").mockImplementation(() => {});
   vi.spyOn(console, "warn").mockImplementation(() => {});
   vi.mocked(saveEventRecord).mockResolvedValue(undefined);
-  vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue([]);
+  vi.mocked(findAllEventRecords).mockResolvedValue([]);
   vi.mocked(getWatchedTabIds).mockResolvedValue([]);
   vi.mocked(startWatching).mockResolvedValue(undefined);
   vi.mocked(stopWatching).mockResolvedValue(undefined);
@@ -62,10 +64,10 @@ function registerAndGetHandler(onCaptureStopped: CaptureStopHandler): WatchStopH
   return handler as WatchStopHandler;
 }
 
-function captureKeyFields(
-  ...types: ("CaptureStarted" | "CaptureStopped")[]
-): EventRecordKeyFields[] {
-  return types.map((type, index) => ({ id: `capture-${index}`, kind: "event", type }));
+function captureRecords(...types: ("CaptureStarted" | "CaptureStopped")[]): EventRecord[] {
+  return types.map((type) =>
+    type === "CaptureStarted" ? newCaptureStartedRecord() : newCaptureStoppedRecord(),
+  );
 }
 
 // Types of the event records stored so far, in order
@@ -112,9 +114,7 @@ describe("startCapturing", () => {
   });
 
   it("closes an inconsistent capture before starting a new one", async () => {
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(
-      captureKeyFields("CaptureStarted"),
-    );
+    vi.mocked(findAllEventRecords).mockResolvedValue(captureRecords("CaptureStarted"));
 
     const result = await startCapturing(1);
 
@@ -124,9 +124,7 @@ describe("startCapturing", () => {
   });
 
   it("does not start another capture while one is in progress", async () => {
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(
-      captureKeyFields("CaptureStarted"),
-    );
+    vi.mocked(findAllEventRecords).mockResolvedValue(captureRecords("CaptureStarted"));
     vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
 
     const result = await startCapturing(1);
@@ -139,9 +137,7 @@ describe("startCapturing", () => {
 
   it("does not start when the inconsistent capture cannot be closed", async () => {
     const error = new Error("storage failed");
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(
-      captureKeyFields("CaptureStarted"),
-    );
+    vi.mocked(findAllEventRecords).mockResolvedValue(captureRecords("CaptureStarted"));
     vi.mocked(saveEventRecord).mockResolvedValue(error);
 
     const result = await startCapturing(1);
@@ -216,16 +212,23 @@ describe("registerCaptureStopHandler", () => {
 
 describe("getOngoingCaptureSessionId", () => {
   it("returns the ID of the record that started the ongoing capture", async () => {
-    const keyFields = captureKeyFields("CaptureStarted", "CaptureStopped", "CaptureStarted");
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(keyFields);
+    const records = captureRecords("CaptureStarted", "CaptureStopped", "CaptureStarted");
+    vi.mocked(findAllEventRecords).mockResolvedValue(records);
 
-    expect(await getOngoingCaptureSessionId()).toBe(keyFields[2]?.id);
+    expect(await getOngoingCaptureSessionId()).toBe(records[2]?.id);
     expect(getWatchedTabIds).not.toHaveBeenCalled();
   });
 
+  it("ignores records other than capture records", async () => {
+    const records = [...captureRecords("CaptureStarted"), newWatchStartedRecord(1)];
+    vi.mocked(findAllEventRecords).mockResolvedValue(records);
+
+    expect(await getOngoingCaptureSessionId()).toBe(records[0]?.id);
+  });
+
   it("returns undefined when the latest capture has stopped", async () => {
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(
-      captureKeyFields("CaptureStarted", "CaptureStopped"),
+    vi.mocked(findAllEventRecords).mockResolvedValue(
+      captureRecords("CaptureStarted", "CaptureStopped"),
     );
 
     expect(await getOngoingCaptureSessionId()).toBeUndefined();
@@ -235,18 +238,9 @@ describe("getOngoingCaptureSessionId", () => {
     expect(await getOngoingCaptureSessionId()).toBeUndefined();
   });
 
-  it("reads the keys of the capture records only", async () => {
-    await getOngoingCaptureSessionId();
-
-    expect(findEventRecordKeyFieldsByTypes).toHaveBeenCalledExactlyOnceWith([
-      "CaptureStarted",
-      "CaptureStopped",
-    ]);
-  });
-
-  it("returns the error when the keys cannot be retrieved", async () => {
+  it("returns the error when the records cannot be retrieved", async () => {
     const error = new Error("storage failed");
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(error);
+    vi.mocked(findAllEventRecords).mockResolvedValue(error);
 
     expect(await getOngoingCaptureSessionId()).toBe(error);
   });
@@ -254,17 +248,15 @@ describe("getOngoingCaptureSessionId", () => {
 
 describe("isCapturing", () => {
   it("returns true when a capture has started and a tab is still watched", async () => {
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(
-      captureKeyFields("CaptureStarted"),
-    );
+    vi.mocked(findAllEventRecords).mockResolvedValue(captureRecords("CaptureStarted"));
     vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
 
     expect(await isCapturing()).toBe(true);
   });
 
   it("returns false when the latest capture has stopped", async () => {
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(
-      captureKeyFields("CaptureStarted", "CaptureStopped"),
+    vi.mocked(findAllEventRecords).mockResolvedValue(
+      captureRecords("CaptureStarted", "CaptureStopped"),
     );
     vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
 
@@ -273,8 +265,8 @@ describe("isCapturing", () => {
   });
 
   it("returns true when a capture has started again after stopping", async () => {
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(
-      captureKeyFields("CaptureStarted", "CaptureStopped", "CaptureStarted"),
+    vi.mocked(findAllEventRecords).mockResolvedValue(
+      captureRecords("CaptureStarted", "CaptureStopped", "CaptureStarted"),
     );
     vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
 
@@ -288,25 +280,21 @@ describe("isCapturing", () => {
   });
 
   it("returns false when no tab is watched even though the capture is left open", async () => {
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(
-      captureKeyFields("CaptureStarted"),
-    );
+    vi.mocked(findAllEventRecords).mockResolvedValue(captureRecords("CaptureStarted"));
 
     expect(await isCapturing()).toBe(false);
   });
 
   it("returns the error when the records cannot be retrieved", async () => {
     const error = new Error("storage failed");
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(error);
+    vi.mocked(findAllEventRecords).mockResolvedValue(error);
 
     expect(await isCapturing()).toBe(error);
   });
 
   it("returns the error when the watched tabs cannot be determined", async () => {
     const error = new Error("targets failed");
-    vi.mocked(findEventRecordKeyFieldsByTypes).mockResolvedValue(
-      captureKeyFields("CaptureStarted"),
-    );
+    vi.mocked(findAllEventRecords).mockResolvedValue(captureRecords("CaptureStarted"));
     vi.mocked(getWatchedTabIds).mockResolvedValue(error);
 
     expect(await isCapturing()).toBe(error);

--- a/src/service-worker/capture-manager.ts
+++ b/src/service-worker/capture-manager.ts
@@ -4,7 +4,7 @@
  */
 
 import { newCaptureStartedRecord, newCaptureStoppedRecord } from "@/common/models/event-record.ts";
-import { findEventRecordKeyFieldsByTypes, saveEventRecord } from "@/common/services/event-store.ts";
+import { findAllEventRecords, saveEventRecord } from "@/common/services/event-store.ts";
 import {
   getWatchedTabIds,
   registerWatchStopHandler,
@@ -26,12 +26,14 @@ export function registerCaptureStopHandler(
 }
 
 export async function getOngoingCaptureSessionId(): Promise<string | undefined | Error> {
-  const keyFields = await findEventRecordKeyFieldsByTypes(["CaptureStarted", "CaptureStopped"]);
-  if (keyFields instanceof Error) {
-    return keyFields;
+  const records = await findAllEventRecords();
+  if (records instanceof Error) {
+    return records;
   }
 
-  const latest = keyFields.at(-1);
+  const latest = records
+    .filter((r) => r.type === "CaptureStarted" || r.type === "CaptureStopped")
+    .at(-1);
   return latest?.type === "CaptureStarted" ? latest.id : undefined;
 }
 

--- a/src/service-worker/http-interception.ts
+++ b/src/service-worker/http-interception.ts
@@ -149,11 +149,6 @@ async function resolvePairedHttpRequest(
   if (httpRequest instanceof Error) {
     console.warn("Failed to find the paired request:", httpRequest);
     return undefined;
-  } else if (httpRequest === undefined) {
-    console.warn("No paired request stored, skipping the HTTP response:", {
-      tabId,
-      fetchRequestId,
-    });
   }
 
   return httpRequest;

--- a/src/service-worker/tab-watcher.test.ts
+++ b/src/service-worker/tab-watcher.test.ts
@@ -15,7 +15,6 @@ import {
 } from "@/service-worker/debugger-controller.ts";
 import {
   getWatchedTabIds,
-  isWatching,
   registerWatchStopHandler,
   startWatching,
   stopWatching,
@@ -258,26 +257,5 @@ describe("getWatchedTabIds", () => {
     vi.mocked(isDebugging).mockResolvedValue(error);
 
     expect(await getWatchedTabIds()).toBe(error);
-  });
-});
-
-describe("isWatching", () => {
-  it("returns true when the tab is watched", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue([newWatchStartedRecord(1)]);
-
-    expect(await isWatching(1)).toBe(true);
-  });
-
-  it("returns false when another tab is watched", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue([newWatchStartedRecord(2)]);
-
-    expect(await isWatching(1)).toBe(false);
-  });
-
-  it("returns the error when the watched tabs cannot be determined", async () => {
-    const error = new Error("storage failed");
-    vi.mocked(findAllEventRecords).mockResolvedValue(error);
-
-    expect(await isWatching(1)).toBe(error);
   });
 });

--- a/src/service-worker/tab-watcher.ts
+++ b/src/service-worker/tab-watcher.ts
@@ -76,15 +76,6 @@ export async function getWatchedTabIds(): Promise<number[] | Error> {
   return actualWatchedTabIds;
 }
 
-export async function isWatching(tabId: number): Promise<boolean | Error> {
-  const tabIds = await getWatchedTabIds();
-  if (tabIds instanceof Error) {
-    return tabIds;
-  }
-
-  return tabIds.includes(tabId);
-}
-
 export async function startWatching(tabId: number): Promise<void | Error> {
   const saveError = await saveEventRecord(newWatchStartedRecord(tabId));
   if (saveError) {


### PR DESCRIPTION
- **Drop event record key lookup from store**
- **Fix noisy warning in SAML recorder tests**
- **Rename findSamlTraces to findSamlTracesByTabI**
- **Drop duplicate warning for missing paired request**
- **Remove unused isWatching**
