### PR TITLE
Use watching state instead of debugger attachment

### DIFF
--- a/src/common/services/session-manager.test.ts
+++ b/src/common/services/session-manager.test.ts
@@ -17,7 +17,7 @@ import {
 import { deleteFlowEntry } from "@/common/services/flow-store.ts";
 import { deleteHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTracesByFlowId, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
-import { isAttached } from "@/common/utils/chrome-debugger.ts";
+import { isWatching } from "@/common/services/watch-query.ts";
 import { deleteSession, getSessionSummaries } from "./session-manager.ts";
 
 vi.mock("@/common/services/capture-query.ts", () => ({
@@ -43,8 +43,8 @@ vi.mock("@/common/services/saml-store.ts", () => ({
   findSamlTracesByFlowId: vi.fn(),
 }));
 
-vi.mock("@/common/utils/chrome-debugger.ts", () => ({
-  isAttached: vi.fn(),
+vi.mock("@/common/services/watch-query.ts", () => ({
+  isWatching: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -53,7 +53,7 @@ beforeEach(() => {
   vi.mocked(findFlowEntriesByTabId).mockResolvedValue([]);
   vi.mocked(getCaptureSession).mockResolvedValue(undefined);
   vi.mocked(findSamlTracesByFlowId).mockResolvedValue([]);
-  vi.mocked(isAttached).mockResolvedValue(false);
+  vi.mocked(isWatching).mockResolvedValue(false);
   vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(makeFlowEntry());
   vi.mocked(findHttpMessagesOfFlow).mockResolvedValue([]);
   vi.mocked(deleteSamlTracesByFlowId).mockResolvedValue(undefined);
@@ -144,11 +144,11 @@ describe("getSessionSummaries", () => {
     expect(result).toMatchObject([{ imported: true, capturing: false }]);
   });
 
-  it("sets capturing when the capture session is ongoing and the debugger is attached", async () => {
+  it("sets capturing when the capture session is ongoing and the tab is watched", async () => {
     vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
     vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession({ endedAt: undefined }));
     vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
-    vi.mocked(isAttached).mockResolvedValue(true);
+    vi.mocked(isWatching).mockResolvedValue(true);
 
     expect(await getSessionSummaries(1)).toMatchObject([{ capturing: true }]);
   });
@@ -157,16 +157,16 @@ describe("getSessionSummaries", () => {
     vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
     vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession());
     vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
-    vi.mocked(isAttached).mockResolvedValue(true);
+    vi.mocked(isWatching).mockResolvedValue(true);
 
     expect(await getSessionSummaries(1)).toMatchObject([{ capturing: false }]);
   });
 
-  it("does not set capturing when the debugger is not attached", async () => {
+  it("does not set capturing when the tab is not watched", async () => {
     vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
     vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession({ endedAt: undefined }));
     vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
-    vi.mocked(isAttached).mockResolvedValue(false);
+    vi.mocked(isWatching).mockResolvedValue(false);
 
     expect(await getSessionSummaries(1)).toMatchObject([{ capturing: false }]);
   });
@@ -204,9 +204,9 @@ describe("getSessionSummaries", () => {
     expect(findSamlTracesByFlowId).not.toHaveBeenCalled();
   });
 
-  it("propagates an error from the debugger", async () => {
-    const error = new Error("debugger error");
-    vi.mocked(isAttached).mockResolvedValue(error);
+  it("propagates an error from the watch query", async () => {
+    const error = new Error("watch query error");
+    vi.mocked(isWatching).mockResolvedValue(error);
 
     expect(await getSessionSummaries(1)).toBe(error);
   });

--- a/src/common/services/session-manager.ts
+++ b/src/common/services/session-manager.ts
@@ -15,7 +15,7 @@ import { deleteFlowEntry } from "@/common/services/flow-store.ts";
 import { deleteHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTracesByFlowId, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 import { summarizeSamlFlow } from "@/common/services/saml-summarizer.ts";
-import { isAttached } from "@/common/utils/chrome-debugger.ts";
+import { isWatching } from "@/common/services/watch-query.ts";
 
 // NOTE: getSessionSummaries has known inefficiencies (e.g., repeated data
 // fetches), but we prioritize simplicity as performance is not a concern at
@@ -28,9 +28,9 @@ import { isAttached } from "@/common/utils/chrome-debugger.ts";
  * @returns An array of session summaries sorted by flow ID in descending order, or an Error
  */
 export async function getSessionSummaries(tabId: number): Promise<SessionSummary[] | Error> {
-  const attached = await isAttached(tabId);
-  if (attached instanceof Error) {
-    return attached;
+  const watching = await isWatching(tabId);
+  if (watching instanceof Error) {
+    return watching;
   }
 
   const flowEntries = await findFlowEntriesByTabId(tabId);
@@ -55,7 +55,7 @@ export async function getSessionSummaries(tabId: number): Promise<SessionSummary
 
     const summary = {
       ...summarizeSamlFlow(flowEntry, captureSession, samlTraces),
-      capturing: isOngoing(captureSession) && attached,
+      capturing: isOngoing(captureSession) && watching,
     };
 
     summaries.push(summary);

--- a/src/common/services/watch-query.test.ts
+++ b/src/common/services/watch-query.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @copyright Internet Initiative Japan Inc. All rights reserved.
+ * @license BSD-3-Clause
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  newDebuggerAttachedRecord,
+  newDebuggerDetachedRecord,
+  newWatchStartedRecord,
+  newWatchStoppedRecord,
+} from "@/common/models/event-record.ts";
+import { findAllEventRecords } from "@/common/services/event-store.ts";
+import { getWatchedTabIds, isWatching } from "./watch-query.ts";
+
+vi.mock("@/common/services/event-store.ts", () => ({
+  findAllEventRecords: vi.fn(),
+}));
+
+//
+// Helpers
+//
+
+const getTargets = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(findAllEventRecords).mockResolvedValue([]);
+  getTargets.mockResolvedValue([]);
+  vi.stubGlobal("chrome", { debugger: { getTargets } });
+});
+
+function attachedTargets(...tabIds: number[]) {
+  return tabIds.map((tabId) => ({ tabId, attached: true }));
+}
+
+//
+// Tests
+//
+
+describe("getWatchedTabIds", () => {
+  it("returns the tabs whose watch has started and not stopped", async () => {
+    vi.mocked(findAllEventRecords).mockResolvedValue([
+      newWatchStartedRecord(1),
+      newDebuggerAttachedRecord(1, false),
+      newWatchStartedRecord(2),
+      newDebuggerAttachedRecord(2, false),
+      newWatchStoppedRecord(1),
+    ]);
+    getTargets.mockResolvedValue(attachedTargets(1, 2));
+
+    expect(await getWatchedTabIds()).toEqual([2]);
+  });
+
+  it("returns the tab when its watch started again after stopping", async () => {
+    vi.mocked(findAllEventRecords).mockResolvedValue([
+      newWatchStartedRecord(1),
+      newWatchStoppedRecord(1),
+      newWatchStartedRecord(1),
+      newDebuggerAttachedRecord(1, false),
+    ]);
+    getTargets.mockResolvedValue(attachedTargets(1));
+
+    expect(await getWatchedTabIds()).toEqual([1]);
+  });
+
+  it("returns an empty array when no watch has started", async () => {
+    expect(await getWatchedTabIds()).toEqual([]);
+  });
+
+  it("drops the tabs that are no longer attached", async () => {
+    vi.mocked(findAllEventRecords).mockResolvedValue([
+      newWatchStartedRecord(1),
+      newDebuggerAttachedRecord(1, false),
+      newWatchStartedRecord(2),
+      newDebuggerAttachedRecord(2, false),
+    ]);
+    getTargets.mockResolvedValue(attachedTargets(1));
+
+    expect(await getWatchedTabIds()).toEqual([1]);
+  });
+
+  it("drops the tab whose latest debugger record is a detach", async () => {
+    vi.mocked(findAllEventRecords).mockResolvedValue([
+      newWatchStartedRecord(1),
+      newDebuggerAttachedRecord(1, false),
+      newDebuggerDetachedRecord(1),
+    ]);
+    getTargets.mockResolvedValue(attachedTargets(1));
+
+    expect(await getWatchedTabIds()).toEqual([]);
+  });
+
+  it("returns the tab that was attached again after a detach", async () => {
+    vi.mocked(findAllEventRecords).mockResolvedValue([
+      newWatchStartedRecord(1),
+      newDebuggerAttachedRecord(1, false),
+      newDebuggerDetachedRecord(1),
+      newDebuggerAttachedRecord(1, true),
+    ]);
+    getTargets.mockResolvedValue(attachedTargets(1));
+
+    expect(await getWatchedTabIds()).toEqual([1]);
+  });
+
+  it("drops the tab that no debugger record says was attached", async () => {
+    vi.mocked(findAllEventRecords).mockResolvedValue([newWatchStartedRecord(1)]);
+    getTargets.mockResolvedValue(attachedTargets(1));
+
+    expect(await getWatchedTabIds()).toEqual([]);
+  });
+
+  it("ignores the debugger records of other tabs", async () => {
+    vi.mocked(findAllEventRecords).mockResolvedValue([
+      newWatchStartedRecord(1),
+      newDebuggerAttachedRecord(2, false),
+    ]);
+    getTargets.mockResolvedValue(attachedTargets(1));
+
+    expect(await getWatchedTabIds()).toEqual([]);
+  });
+
+  it("returns the error when the records cannot be retrieved", async () => {
+    const error = new Error("storage failed");
+    vi.mocked(findAllEventRecords).mockResolvedValue(error);
+
+    expect(await getWatchedTabIds()).toBe(error);
+  });
+
+  it("returns an error when the debugger targets cannot be retrieved", async () => {
+    vi.mocked(findAllEventRecords).mockResolvedValue([
+      newWatchStartedRecord(1),
+      newDebuggerAttachedRecord(1, false),
+    ]);
+    getTargets.mockRejectedValue(new Error("targets failed"));
+
+    expect(await getWatchedTabIds()).toBeInstanceOf(Error);
+  });
+});
+
+describe("isWatching", () => {
+  it("returns true when the tab is watched", async () => {
+    vi.mocked(findAllEventRecords).mockResolvedValue([
+      newWatchStartedRecord(1),
+      newDebuggerAttachedRecord(1, false),
+    ]);
+    getTargets.mockResolvedValue(attachedTargets(1));
+
+    expect(await isWatching(1)).toBe(true);
+  });
+
+  it("returns false when another tab is watched", async () => {
+    vi.mocked(findAllEventRecords).mockResolvedValue([
+      newWatchStartedRecord(2),
+      newDebuggerAttachedRecord(2, false),
+    ]);
+    getTargets.mockResolvedValue(attachedTargets(2));
+
+    expect(await isWatching(1)).toBe(false);
+  });
+
+  it("returns the error when the watched tabs cannot be determined", async () => {
+    const error = new Error("storage failed");
+    vi.mocked(findAllEventRecords).mockResolvedValue(error);
+
+    expect(await isWatching(1)).toBe(error);
+  });
+});

--- a/src/common/services/watch-query.ts
+++ b/src/common/services/watch-query.ts
@@ -1,0 +1,82 @@
+/**
+ * @copyright Internet Initiative Japan Inc. All rights reserved.
+ * @license BSD-3-Clause
+ */
+
+import { findAllEventRecords } from "@/common/services/event-store.ts";
+import { isAttached } from "@/common/utils/chrome-debugger.ts";
+
+export async function isWatching(tabId: number): Promise<boolean | Error> {
+  const tabIds = await getWatchedTabIds();
+  if (tabIds instanceof Error) {
+    return tabIds;
+  }
+
+  return tabIds.includes(tabId);
+}
+
+export async function getWatchedTabIds(): Promise<number[] | Error> {
+  // How the watch record and the debugging state decide the result, per tab:
+  //
+  //   record  | debugging | result
+  //   --------+-----------+-------
+  //   started | yes       | watched
+  //   started | no        | not watched -- the stop record was lost [1]
+  //   stopped | yes       | not watched -- the record wins [2]
+  //   stopped | no        | not watched
+  //
+  // [1] The debugger is already gone, so nothing is being watched on that tab.
+  // [2] The debugger is attached without a watch. The user can detach from the banner.
+
+  const records = await findAllEventRecords();
+  if (records instanceof Error) {
+    return records;
+  }
+
+  const recordedWatchedTabIds = new Set<number>();
+  for (const record of records) {
+    if (record.type === "WatchStarted") {
+      recordedWatchedTabIds.add(record.tabId);
+    } else if (record.type === "WatchStopped") {
+      recordedWatchedTabIds.delete(record.tabId);
+    }
+  }
+
+  const actualWatchedTabIds: number[] = [];
+  for (const tabId of recordedWatchedTabIds) {
+    const debugging = await isDebugging(tabId);
+    if (debugging instanceof Error) {
+      return debugging;
+    } else if (debugging) {
+      actualWatchedTabIds.push(tabId);
+    }
+  }
+
+  return actualWatchedTabIds;
+}
+
+async function isDebugging(tabId: number): Promise<boolean | Error> {
+  // How the debugger record and the chrome.debugger API decide the result:
+  //
+  //   record   | chrome | result
+  //   ---------+--------+-------
+  //   attached | yes    | debugging
+  //   attached | no     | not debugging -- the detach record was lost [1]
+  //   detached | yes    | not debugging -- the record wins [2]
+  //   detached | no     | not debugging
+  //
+  // [1] The record write was missed or incomplete, so the record alone cannot be trusted.
+  // [2] The attachment may be DevTools or another extension. The attach record is reliable
+  //     because a failed write triggers an immediate detach, so trust it here.
+
+  const records = await findAllEventRecords();
+  if (records instanceof Error) {
+    return records;
+  }
+
+  const latest = records.findLast(
+    (r) => (r.type === "DebuggerAttached" || r.type === "DebuggerDetached") && r.tabId === tabId,
+  );
+
+  return latest !== undefined && latest.type === "DebuggerAttached" && (await isAttached(tabId));
+}

--- a/src/service-worker/capture-manager.test.ts
+++ b/src/service-worker/capture-manager.test.ts
@@ -11,8 +11,8 @@ import {
   newWatchStartedRecord,
 } from "@/common/models/event-record.ts";
 import { findAllEventRecords, saveEventRecord } from "@/common/services/event-store.ts";
+import { getWatchedTabIds } from "@/common/services/watch-query.ts";
 import {
-  getWatchedTabIds,
   registerWatchStopHandler,
   startWatching,
   stopWatching,
@@ -30,8 +30,11 @@ vi.mock("@/common/services/event-store.ts", () => ({
   saveEventRecord: vi.fn(),
 }));
 
-vi.mock("@/service-worker/tab-watcher.ts", () => ({
+vi.mock("@/common/services/watch-query.ts", () => ({
   getWatchedTabIds: vi.fn(),
+}));
+
+vi.mock("@/service-worker/tab-watcher.ts", () => ({
   registerWatchStopHandler: vi.fn(),
   startWatching: vi.fn(),
   stopWatching: vi.fn(),

--- a/src/service-worker/capture-manager.ts
+++ b/src/service-worker/capture-manager.ts
@@ -5,8 +5,8 @@
 
 import { newCaptureStartedRecord, newCaptureStoppedRecord } from "@/common/models/event-record.ts";
 import { findAllEventRecords, saveEventRecord } from "@/common/services/event-store.ts";
+import { getWatchedTabIds } from "@/common/services/watch-query.ts";
 import {
-  getWatchedTabIds,
   registerWatchStopHandler,
   startWatching,
   stopWatching,

--- a/src/service-worker/debugger-controller.test.ts
+++ b/src/service-worker/debugger-controller.test.ts
@@ -4,20 +4,14 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { saveEventRecord } from "@/common/services/event-store.ts";
 import {
-  newDebuggerAttachedRecord,
-  newDebuggerDetachedRecord,
-} from "@/common/models/event-record.ts";
-import { findAllEventRecords, saveEventRecord } from "@/common/services/event-store.ts";
-import {
-  isDebugging,
   registerDebuggerDetachHandler,
   startDebugging,
   stopDebugging,
 } from "./debugger-controller.ts";
 
 vi.mock("@/common/services/event-store.ts", () => ({
-  findAllEventRecords: vi.fn(),
   saveEventRecord: vi.fn(),
 }));
 
@@ -43,7 +37,6 @@ beforeEach(() => {
   attach.mockReset();
   detach.mockReset();
   vi.mocked(saveEventRecord).mockReset().mockResolvedValue(undefined);
-  vi.mocked(findAllEventRecords).mockReset().mockResolvedValue([]);
   vi.stubGlobal("chrome", {
     debugger: {
       onDetach: {
@@ -192,62 +185,5 @@ describe("stopDebugging", () => {
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).cause).toBe(error);
     expect(detach).toHaveBeenCalledOnce();
-  });
-});
-
-describe("isDebugging", () => {
-  it("returns true when the tab is attached and the records say so", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue([newDebuggerAttachedRecord(1, false)]);
-    getTargets.mockResolvedValue([{ tabId: 1, attached: true }]);
-
-    expect(await isDebugging(1)).toBe(true);
-  });
-
-  it("returns false when no record says the tab was attached", async () => {
-    getTargets.mockResolvedValue([{ tabId: 1, attached: true }]);
-
-    expect(await isDebugging(1)).toBe(false);
-  });
-
-  it("returns false when the latest record is a detach", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue([
-      newDebuggerAttachedRecord(1, false),
-      newDebuggerDetachedRecord(1),
-    ]);
-    getTargets.mockResolvedValue([{ tabId: 1, attached: true }]);
-
-    expect(await isDebugging(1)).toBe(false);
-  });
-
-  it("returns true when the tab was re-attached after a detach", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue([
-      newDebuggerAttachedRecord(1, false),
-      newDebuggerDetachedRecord(1),
-      newDebuggerAttachedRecord(1, true),
-    ]);
-    getTargets.mockResolvedValue([{ tabId: 1, attached: true }]);
-
-    expect(await isDebugging(1)).toBe(true);
-  });
-
-  it("returns false when the records say so but the tab is no longer attached", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue([newDebuggerAttachedRecord(1, false)]);
-    getTargets.mockResolvedValue([]);
-
-    expect(await isDebugging(1)).toBe(false);
-  });
-
-  it("ignores records of other tabs", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue([newDebuggerAttachedRecord(2, false)]);
-    getTargets.mockResolvedValue([{ tabId: 1, attached: true }]);
-
-    expect(await isDebugging(1)).toBe(false);
-  });
-
-  it("returns the error when the records cannot be retrieved", async () => {
-    const error = new Error("storage failed");
-    vi.mocked(findAllEventRecords).mockResolvedValue(error);
-
-    expect(await isDebugging(1)).toBe(error);
   });
 });

--- a/src/service-worker/debugger-controller.ts
+++ b/src/service-worker/debugger-controller.ts
@@ -7,7 +7,7 @@ import {
   newDebuggerAttachedRecord,
   newDebuggerDetachedRecord,
 } from "@/common/models/event-record.ts";
-import { findAllEventRecords, saveEventRecord } from "@/common/services/event-store.ts";
+import { saveEventRecord } from "@/common/services/event-store.ts";
 import { isAttached } from "@/common/utils/chrome-debugger.ts";
 
 // chrome.debugger.DetachReason is an enum, which is not compatible with the callback parameter
@@ -38,32 +38,6 @@ export function registerDebuggerDetachHandler(
       console.error("Unexpected error in debugger.onDetach event:", { error: err });
     });
   });
-}
-
-export async function isDebugging(tabId: number): Promise<boolean | Error> {
-  // How the debugger record and the chrome.debugger API decide the result:
-  //
-  //   record   | chrome | result
-  //   ---------+--------+-------
-  //   attached | yes    | debugging
-  //   attached | no     | not debugging -- the detach record was lost [1]
-  //   detached | yes    | not debugging -- the record wins [2]
-  //   detached | no     | not debugging
-  //
-  // [1] The record write was missed or incomplete, so the record alone cannot be trusted.
-  // [2] The attachment may be DevTools or another extension. The attach record is reliable
-  //     because a failed write triggers an immediate detach, so trust it here.
-
-  const records = await findAllEventRecords();
-  if (records instanceof Error) {
-    return records;
-  }
-
-  const latest = records.findLast(
-    (r) => (r.type === "DebuggerAttached" || r.type === "DebuggerDetached") && r.tabId === tabId,
-  );
-
-  return latest !== undefined && latest.type === "DebuggerAttached" && (await isAttached(tabId));
 }
 
 export async function startDebugging(tabId: number, retry = false): Promise<void | Error> {

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -7,7 +7,7 @@ import { publishCaptureTerminatedEvent, publishSessionUpdateEvent } from "@/comm
 import { registerStartMonitoringHandler, registerStopMonitoringHandler } from "@/common/rpc.ts";
 import { dumpSessionArchive, loadSessionArchive } from "@/common/services/session-archiver.ts";
 import { deleteSession, getSessionSummaries } from "@/common/services/session-manager.ts";
-import { isAttached } from "@/common/utils/chrome-debugger.ts";
+import { isWatching } from "@/common/services/watch-query.ts";
 import {
   getAllSessionStorageItems,
   getSessionStorageBytesInUse,
@@ -67,10 +67,10 @@ function init() {
 
   registerSidePanelOpenHandler();
   registerSidePanelCloseHandler(async (tabId) => {
-    const attached = await isAttached(tabId);
-    if (attached instanceof Error) {
-      console.warn("Failed to get debugging state:", attached);
-    } else if (attached) {
+    const watching = await isWatching(tabId);
+    if (watching instanceof Error) {
+      console.warn("Failed to get watching state:", watching);
+    } else if (watching) {
       const stopError = await onStopMonitoring(tabId);
       if (stopError) {
         console.warn("Failed to stop monitoring:", stopError);

--- a/src/service-worker/tab-watcher.test.ts
+++ b/src/service-worker/tab-watcher.test.ts
@@ -4,24 +4,16 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { newWatchStartedRecord, newWatchStoppedRecord } from "@/common/models/event-record.ts";
-import { findAllEventRecords, saveEventRecord } from "@/common/services/event-store.ts";
+import { saveEventRecord } from "@/common/services/event-store.ts";
 import { tabExists } from "@/common/utils/chrome-tabs.ts";
 import {
-  isDebugging,
   registerDebuggerDetachHandler,
   startDebugging,
   stopDebugging,
 } from "@/service-worker/debugger-controller.ts";
-import {
-  getWatchedTabIds,
-  registerWatchStopHandler,
-  startWatching,
-  stopWatching,
-} from "./tab-watcher.ts";
+import { registerWatchStopHandler, startWatching, stopWatching } from "./tab-watcher.ts";
 
 vi.mock("@/common/services/event-store.ts", () => ({
-  findAllEventRecords: vi.fn(),
   saveEventRecord: vi.fn(),
 }));
 
@@ -30,7 +22,6 @@ vi.mock("@/common/utils/chrome-tabs.ts", () => ({
 }));
 
 vi.mock("@/service-worker/debugger-controller.ts", () => ({
-  isDebugging: vi.fn(),
   registerDebuggerDetachHandler: vi.fn(),
   startDebugging: vi.fn(),
   stopDebugging: vi.fn(),
@@ -48,8 +39,6 @@ beforeEach(() => {
   vi.spyOn(console, "info").mockImplementation(() => {});
   vi.spyOn(console, "warn").mockImplementation(() => {});
   vi.mocked(saveEventRecord).mockResolvedValue(undefined);
-  vi.mocked(findAllEventRecords).mockResolvedValue([]);
-  vi.mocked(isDebugging).mockResolvedValue(true);
   vi.mocked(startDebugging).mockResolvedValue(undefined);
   vi.mocked(stopDebugging).mockResolvedValue(undefined);
 });
@@ -206,56 +195,5 @@ describe("registerWatchStopHandler", () => {
 
     expect(onWatchStopped).toHaveBeenCalledExactlyOnceWith(1);
     expect(console.warn).toHaveBeenCalled();
-  });
-});
-
-describe("getWatchedTabIds", () => {
-  it("returns the tabs whose watch has started and not stopped", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue([
-      newWatchStartedRecord(1),
-      newWatchStartedRecord(2),
-      newWatchStoppedRecord(1),
-    ]);
-
-    expect(await getWatchedTabIds()).toEqual([2]);
-  });
-
-  it("returns the tab when its watch started again after stopping", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue([
-      newWatchStartedRecord(1),
-      newWatchStoppedRecord(1),
-      newWatchStartedRecord(1),
-    ]);
-
-    expect(await getWatchedTabIds()).toEqual([1]);
-  });
-
-  it("drops the tabs that are no longer debugged", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue([
-      newWatchStartedRecord(1),
-      newWatchStartedRecord(2),
-    ]);
-    vi.mocked(isDebugging).mockImplementation(async (tabId) => tabId === 1);
-
-    expect(await getWatchedTabIds()).toEqual([1]);
-  });
-
-  it("returns an empty array when no watch has started", async () => {
-    expect(await getWatchedTabIds()).toEqual([]);
-  });
-
-  it("returns the error when the records cannot be retrieved", async () => {
-    const error = new Error("storage failed");
-    vi.mocked(findAllEventRecords).mockResolvedValue(error);
-
-    expect(await getWatchedTabIds()).toBe(error);
-  });
-
-  it("returns the error when the debugging state cannot be determined", async () => {
-    const error = new Error("targets failed");
-    vi.mocked(findAllEventRecords).mockResolvedValue([newWatchStartedRecord(1)]);
-    vi.mocked(isDebugging).mockResolvedValue(error);
-
-    expect(await getWatchedTabIds()).toBe(error);
   });
 });

--- a/src/service-worker/tab-watcher.ts
+++ b/src/service-worker/tab-watcher.ts
@@ -4,10 +4,9 @@
  */
 
 import { newWatchStartedRecord, newWatchStoppedRecord } from "@/common/models/event-record.ts";
-import { findAllEventRecords, saveEventRecord } from "@/common/services/event-store.ts";
+import { saveEventRecord } from "@/common/services/event-store.ts";
 import { tabExists } from "@/common/utils/chrome-tabs.ts";
 import {
-  isDebugging,
   registerDebuggerDetachHandler,
   startDebugging,
   stopDebugging,
@@ -34,46 +33,6 @@ export function registerWatchStopHandler(onWatchStopped: (tabId: number) => Prom
 
     await onWatchStopped(tabId);
   });
-}
-
-export async function getWatchedTabIds(): Promise<number[] | Error> {
-  // How the watch record and the debugging state decide the result, per tab:
-  //
-  //   record  | debugging | result
-  //   --------+-----------+-------
-  //   started | yes       | watched
-  //   started | no        | not watched -- the stop record was lost [1]
-  //   stopped | yes       | not watched -- the record wins [2]
-  //   stopped | no        | not watched
-  //
-  // [1] The debugger is already gone, so nothing is being watched on that tab.
-  // [2] The debugger is attached without a watch. The user can detach from the banner.
-
-  const records = await findAllEventRecords();
-  if (records instanceof Error) {
-    return records;
-  }
-
-  const recordedWatchedTabIds = new Set<number>();
-  for (const record of records) {
-    if (record.type === "WatchStarted") {
-      recordedWatchedTabIds.add(record.tabId);
-    } else if (record.type === "WatchStopped") {
-      recordedWatchedTabIds.delete(record.tabId);
-    }
-  }
-
-  const actualWatchedTabIds: number[] = [];
-  for (const tabId of recordedWatchedTabIds) {
-    const debugging = await isDebugging(tabId);
-    if (debugging instanceof Error) {
-      return debugging;
-    } else if (debugging) {
-      actualWatchedTabIds.push(tabId);
-    }
-  }
-
-  return actualWatchedTabIds;
 }
 
 export async function startWatching(tabId: number): Promise<void | Error> {


### PR DESCRIPTION
- **Derive capturing state from event log**
- **Guard side panel close with watching state**
