### PR TITLE
List SSO flows across tabs, not per tab

### DIFF
--- a/src/common/services/capture-query.test.ts
+++ b/src/common/services/capture-query.test.ts
@@ -15,15 +15,26 @@ import {
   newWatchStoppedRecord,
 } from "@/common/models/event-record.ts";
 import { findAllEventRecords } from "@/common/services/event-store.ts";
-import { getCaptureSession, getCaptureSessions } from "./capture-query.ts";
+import { getWatchedTabIds } from "@/common/services/watch-query.ts";
+import {
+  getCaptureSession,
+  getCaptureSessions,
+  getOngoingCaptureSessionId,
+  isCapturing,
+} from "./capture-query.ts";
 
 vi.mock("@/common/services/event-store.ts", () => ({
   findAllEventRecords: vi.fn(),
 }));
 
+vi.mock("@/common/services/watch-query.ts", () => ({
+  getWatchedTabIds: vi.fn(),
+}));
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(findAllEventRecords).mockResolvedValue([]);
+  vi.mocked(getWatchedTabIds).mockResolvedValue([]);
 });
 
 //
@@ -46,6 +57,10 @@ function record(type: EventRecord["type"]): EventRecord {
 
 function mockRecords(...records: EventRecord[]): void {
   vi.mocked(findAllEventRecords).mockResolvedValue(records);
+}
+
+function captureRecords(...types: ("CaptureStarted" | "CaptureStopped")[]): EventRecord[] {
+  return types.map(record);
 }
 
 //
@@ -169,5 +184,90 @@ describe("getCaptureSession", () => {
     vi.mocked(findAllEventRecords).mockResolvedValue(error);
 
     expect(await getCaptureSession("unknown")).toBe(error);
+  });
+});
+
+describe("getOngoingCaptureSessionId", () => {
+  it("returns the ID of the record that started the ongoing capture", async () => {
+    const records = captureRecords("CaptureStarted", "CaptureStopped", "CaptureStarted");
+    mockRecords(...records);
+
+    expect(await getOngoingCaptureSessionId()).toBe(records[2]?.id);
+    expect(getWatchedTabIds).not.toHaveBeenCalled();
+  });
+
+  it("ignores records other than capture records", async () => {
+    const started = record("CaptureStarted");
+    mockRecords(started, record("WatchStarted"));
+
+    expect(await getOngoingCaptureSessionId()).toBe(started.id);
+  });
+
+  it("returns undefined when the latest capture has stopped", async () => {
+    mockRecords(...captureRecords("CaptureStarted", "CaptureStopped"));
+
+    expect(await getOngoingCaptureSessionId()).toBeUndefined();
+  });
+
+  it("returns undefined when no capture has started", async () => {
+    expect(await getOngoingCaptureSessionId()).toBeUndefined();
+  });
+
+  it("returns the error when the records cannot be retrieved", async () => {
+    const error = new Error("storage failed");
+    vi.mocked(findAllEventRecords).mockResolvedValue(error);
+
+    expect(await getOngoingCaptureSessionId()).toBe(error);
+  });
+});
+
+describe("isCapturing", () => {
+  it("returns true when a capture has started and a tab is still watched", async () => {
+    mockRecords(...captureRecords("CaptureStarted"));
+    vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
+
+    expect(await isCapturing()).toBe(true);
+  });
+
+  it("returns false when the latest capture has stopped", async () => {
+    mockRecords(...captureRecords("CaptureStarted", "CaptureStopped"));
+    vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
+
+    expect(await isCapturing()).toBe(false);
+    expect(getWatchedTabIds).not.toHaveBeenCalled();
+  });
+
+  it("returns true when a capture has started again after stopping", async () => {
+    mockRecords(...captureRecords("CaptureStarted", "CaptureStopped", "CaptureStarted"));
+    vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
+
+    expect(await isCapturing()).toBe(true);
+  });
+
+  it("returns false when no capture has started", async () => {
+    vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
+
+    expect(await isCapturing()).toBe(false);
+  });
+
+  it("returns false when no tab is watched even though the capture is left open", async () => {
+    mockRecords(...captureRecords("CaptureStarted"));
+
+    expect(await isCapturing()).toBe(false);
+  });
+
+  it("returns the error when the records cannot be retrieved", async () => {
+    const error = new Error("storage failed");
+    vi.mocked(findAllEventRecords).mockResolvedValue(error);
+
+    expect(await isCapturing()).toBe(error);
+  });
+
+  it("returns the error when the watched tabs cannot be determined", async () => {
+    const error = new Error("targets failed");
+    mockRecords(...captureRecords("CaptureStarted"));
+    vi.mocked(getWatchedTabIds).mockResolvedValue(error);
+
+    expect(await isCapturing()).toBe(error);
   });
 });

--- a/src/common/services/capture-query.ts
+++ b/src/common/services/capture-query.ts
@@ -6,6 +6,7 @@
 import { type CaptureSession } from "@/common/models/capture-session.ts";
 import { type EventRecord } from "@/common/models/event-record.ts";
 import { findAllEventRecords } from "@/common/services/event-store.ts";
+import { getWatchedTabIds } from "@/common/services/watch-query.ts";
 
 export async function getCaptureSession(
   captureSessionId: string,
@@ -70,4 +71,45 @@ function terminateLastOngoingCaptureSession(
     : captureSessions.map((s) =>
         s.id === ongoingCaptureSession.id ? { ...ongoingCaptureSession, endedAt } : s,
       );
+}
+
+export async function isCapturing(): Promise<boolean | Error> {
+  // How the capture record and the watched tabs decide the result:
+  //
+  //   record | watched tab | result
+  //   -------+-------------+-------
+  //   open   | yes         | capturing
+  //   open   | no          | not capturing -- the stop record was lost [1]
+  //   closed | yes         | not capturing -- the record wins [2]
+  //   closed | no          | not capturing
+  //
+  // [1] The debugger is already detached, so staying "capturing" would show a recording that can
+  //     never be stopped.
+  // [2] The user can detach from the banner.
+
+  const sessionId = await getOngoingCaptureSessionId();
+  if (sessionId instanceof Error) {
+    return sessionId;
+  } else if (sessionId === undefined) {
+    return false;
+  }
+
+  const tabIds = await getWatchedTabIds();
+  if (tabIds instanceof Error) {
+    return tabIds;
+  }
+
+  return 0 < tabIds.length;
+}
+
+export async function getOngoingCaptureSessionId(): Promise<string | undefined | Error> {
+  const records = await findAllEventRecords();
+  if (records instanceof Error) {
+    return records;
+  }
+
+  const latest = records
+    .filter((r) => r.type === "CaptureStarted" || r.type === "CaptureStopped")
+    .at(-1);
+  return latest?.type === "CaptureStarted" ? latest.id : undefined;
 }

--- a/src/common/services/flow-query.test.ts
+++ b/src/common/services/flow-query.test.ts
@@ -4,21 +4,11 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
-import { findFlowEntryById } from "@/common/services/flow-store.ts";
 import { findHttpMessagesByIds } from "@/common/services/http-store.ts";
-import { findSamlTracesByFlowId, findSamlTracesByTabId } from "@/common/services/saml-store.ts";
-import {
-  findFlowEntriesByTabId,
-  findFlowEntryByCorrelationKeyInTab,
-  findHttpMessagesOfFlow,
-} from "./flow-query.ts";
-
-vi.mock("@/common/services/flow-store.ts", () => ({
-  findFlowEntryById: vi.fn(),
-}));
+import { findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
+import { findHttpMessagesOfFlow } from "./flow-query.ts";
 
 vi.mock("@/common/services/http-store.ts", () => ({
   findHttpMessagesByIds: vi.fn(),
@@ -26,7 +16,6 @@ vi.mock("@/common/services/http-store.ts", () => ({
 
 vi.mock("@/common/services/saml-store.ts", () => ({
   findSamlTracesByFlowId: vi.fn(),
-  findSamlTracesByTabId: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -41,10 +30,6 @@ function makeSamlTrace(httpMessageId: string, flowId = "flow-1"): SamlTrace {
   return { httpMessageId, flowId } as SamlTrace;
 }
 
-function makeFlowEntry(id: string, correlationKey = `corr-${id}`): FlowEntry {
-  return { id, captureSessionId: "cs-1", protocol: "saml", correlationKey };
-}
-
 function makeRequest(id: string): HttpMessage {
   return { id, stage: "Request" } as HttpMessage;
 }
@@ -57,13 +42,6 @@ function makeResponse(id: string, pairedHttpRequestId: string): HttpMessage {
 function mockHttpStore(...httpMessages: HttpMessage[]): void {
   vi.mocked(findHttpMessagesByIds).mockImplementation(async (ids) =>
     httpMessages.filter((m) => ids.includes(m.id)),
-  );
-}
-
-// Serves the given flows from the mocked store by their IDs
-function mockFlowStore(...flowEntries: FlowEntry[]): void {
-  vi.mocked(findFlowEntryById).mockImplementation(async (id) =>
-    flowEntries.find((f) => f.id === id),
   );
 }
 
@@ -135,87 +113,5 @@ describe("findHttpMessagesOfFlow", () => {
       .mockResolvedValueOnce(error);
 
     expect(await findHttpMessagesOfFlow("flow-1")).toBe(error);
-  });
-});
-
-describe("findFlowEntriesByTabId", () => {
-  it("returns the flows of the traces in the tab, newest first", async () => {
-    const flow1 = makeFlowEntry("flow-1");
-    const flow2 = makeFlowEntry("flow-2");
-    vi.mocked(findSamlTracesByTabId).mockResolvedValue([
-      makeSamlTrace("msg-1", "flow-1"),
-      makeSamlTrace("msg-2", "flow-1"),
-      makeSamlTrace("msg-3", "flow-2"),
-    ]);
-    mockFlowStore(flow1, flow2);
-
-    const result = await findFlowEntriesByTabId(1);
-
-    expect(findSamlTracesByTabId).toHaveBeenCalledWith(1);
-    expect(findFlowEntryById).toHaveBeenCalledTimes(2);
-    expect(result).toEqual([flow2, flow1]);
-  });
-
-  it("returns an empty array when the tab has no traces", async () => {
-    vi.mocked(findSamlTracesByTabId).mockResolvedValue([]);
-
-    expect(await findFlowEntriesByTabId(1)).toEqual([]);
-    expect(findFlowEntryById).not.toHaveBeenCalled();
-  });
-
-  it("skips traces without a flow entry with a warning", async () => {
-    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const flow1 = makeFlowEntry("flow-1");
-    vi.mocked(findSamlTracesByTabId).mockResolvedValue([
-      makeSamlTrace("msg-1", "flow-1"),
-      makeSamlTrace("msg-2", "flow-x"),
-    ]);
-    mockFlowStore(flow1);
-
-    expect(await findFlowEntriesByTabId(1)).toEqual([flow1]);
-    expect(consoleWarn).toHaveBeenCalledOnce();
-  });
-
-  it("returns an error when the traces cannot be found", async () => {
-    const error = new Error("saml store error");
-    vi.mocked(findSamlTracesByTabId).mockResolvedValue(error);
-
-    expect(await findFlowEntriesByTabId(1)).toBe(error);
-    expect(findFlowEntryById).not.toHaveBeenCalled();
-  });
-
-  it("returns an error when a flow cannot be found", async () => {
-    const error = new Error("flow store error");
-    vi.mocked(findSamlTracesByTabId).mockResolvedValue([makeSamlTrace("msg-1")]);
-    vi.mocked(findFlowEntryById).mockResolvedValue(error);
-
-    expect(await findFlowEntriesByTabId(1)).toBe(error);
-  });
-});
-
-describe("findFlowEntryByCorrelationKeyInTab", () => {
-  it("returns the flow with the correlation key among the flows of the tab", async () => {
-    const flow2 = makeFlowEntry("flow-2");
-    vi.mocked(findSamlTracesByTabId).mockResolvedValue([
-      makeSamlTrace("msg-1", "flow-1"),
-      makeSamlTrace("msg-2", "flow-2"),
-    ]);
-    mockFlowStore(makeFlowEntry("flow-1"), flow2);
-
-    expect(await findFlowEntryByCorrelationKeyInTab(1, "corr-flow-2")).toEqual(flow2);
-  });
-
-  it("returns undefined when no flow of the tab has the correlation key", async () => {
-    vi.mocked(findSamlTracesByTabId).mockResolvedValue([makeSamlTrace("msg-1", "flow-1")]);
-    mockFlowStore(makeFlowEntry("flow-1"));
-
-    expect(await findFlowEntryByCorrelationKeyInTab(1, "corr-x")).toBeUndefined();
-  });
-
-  it("returns an error when the flows cannot be found", async () => {
-    const error = new Error("saml store error");
-    vi.mocked(findSamlTracesByTabId).mockResolvedValue(error);
-
-    expect(await findFlowEntryByCorrelationKeyInTab(1, "corr-flow-1")).toBe(error);
   });
 });

--- a/src/common/services/flow-query.ts
+++ b/src/common/services/flow-query.ts
@@ -3,11 +3,9 @@
  * @license BSD-3-Clause
  */
 
-import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type HttpMessage } from "@/common/models/http-message.ts";
-import { findFlowEntryById } from "@/common/services/flow-store.ts";
 import { findHttpMessagesByIds } from "@/common/services/http-store.ts";
-import { findSamlTracesByFlowId, findSamlTracesByTabId } from "@/common/services/saml-store.ts";
+import { findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 
 export async function findHttpMessagesOfFlow(flowId: string): Promise<HttpMessage[] | Error> {
   const samlTraces = await findSamlTracesByFlowId(flowId);
@@ -34,42 +32,4 @@ export async function findHttpMessagesOfFlow(flowId: string): Promise<HttpMessag
   }
 
   return [...httpMessages, ...pairedHttpRequests].toSorted((a, b) => (a.id < b.id ? -1 : 1));
-}
-
-export async function findFlowEntriesByTabId(tabId: number): Promise<FlowEntry[] | Error> {
-  const samlTraces = await findSamlTracesByTabId(tabId);
-  if (samlTraces instanceof Error) {
-    return samlTraces;
-  }
-
-  const flowIds = [...new Set(samlTraces.map((t) => t.flowId))].toSorted((a, b) =>
-    a < b ? 1 : -1,
-  );
-
-  const flowEntries: FlowEntry[] = [];
-  for (const flowId of flowIds) {
-    const flowEntry = await findFlowEntryById(flowId);
-    if (flowEntry instanceof Error) {
-      return flowEntry;
-    } else if (flowEntry === undefined) {
-      console.warn("No flow entry for the traces:", { flowId });
-      continue;
-    }
-
-    flowEntries.push(flowEntry);
-  }
-
-  return flowEntries;
-}
-
-export async function findFlowEntryByCorrelationKeyInTab(
-  tabId: number,
-  correlationKey: string,
-): Promise<FlowEntry | undefined | Error> {
-  const flowEntries = await findFlowEntriesByTabId(tabId);
-  if (flowEntries instanceof Error) {
-    return flowEntries;
-  }
-
-  return flowEntries.find((f) => f.correlationKey === correlationKey);
 }

--- a/src/common/services/flow-store.test.ts
+++ b/src/common/services/flow-store.test.ts
@@ -13,7 +13,7 @@ import {
 } from "@/common/utils/chrome-storage.ts";
 import {
   deleteFlowEntry,
-  findFlowEntriesByCaptureSessionId,
+  findAllFlowEntries,
   findFlowEntryByCorrelationKey,
   findFlowEntryById,
   saveFlowEntry,
@@ -86,27 +86,20 @@ describe("deleteFlowEntry", () => {
   });
 });
 
-describe("findFlowEntriesByCaptureSessionId", () => {
-  it("retrieves the flows of the capture session, newest first", async () => {
+describe("findAllFlowEntries", () => {
+  it("retrieves every flow, newest first", async () => {
     const first = newFlowEntry("cs-1", "saml", "key-1");
     const second = newFlowEntry("cs-1", "saml", "key-2");
-    const third = newFlowEntry("cs-1", "saml", "key-3");
+    const third = newFlowEntry("cs-2", "saml", "key-3");
     mockStorage(second, third, first);
 
-    expect(await findFlowEntriesByCaptureSessionId("cs-1")).toEqual([third, second, first]);
+    expect(await findAllFlowEntries()).toEqual([third, second, first]);
   });
 
-  it("excludes the flows of other capture sessions", async () => {
-    const target = newFlowEntry("cs-1", "saml", "key");
-    mockStorage(newFlowEntry("cs-2", "saml", "key"), target);
+  it("returns an empty array when no flow is stored", async () => {
+    mockStorage();
 
-    expect(await findFlowEntriesByCaptureSessionId("cs-1")).toEqual([target]);
-  });
-
-  it("returns an empty array when the capture session has no flow", async () => {
-    mockStorage(newFlowEntry("cs-2", "saml", "key"));
-
-    expect(await findFlowEntriesByCaptureSessionId("cs-1")).toEqual([]);
+    expect(await findAllFlowEntries()).toEqual([]);
   });
 
   it("ignores keys that are not flow entry keys", async () => {
@@ -119,7 +112,7 @@ describe("findFlowEntriesByCaptureSessionId", () => {
       keyOf(flow),
     ]);
 
-    expect(await findFlowEntriesByCaptureSessionId("cs-1")).toEqual([flow]);
+    expect(await findAllFlowEntries()).toEqual([flow]);
   });
 
   it("skips invalid flows with a warning", async () => {
@@ -131,7 +124,7 @@ describe("findFlowEntriesByCaptureSessionId", () => {
       [keyOf(invalid)]: invalid,
     });
 
-    expect(await findFlowEntriesByCaptureSessionId("cs-1")).toEqual([valid]);
+    expect(await findAllFlowEntries()).toEqual([valid]);
     expect(console.warn).toHaveBeenCalledExactlyOnceWith("Invalid flow entry:", invalid);
   });
 
@@ -139,7 +132,7 @@ describe("findFlowEntriesByCaptureSessionId", () => {
     const error = new Error("storage failed");
     vi.mocked(getAllSessionStorageKeys).mockResolvedValue(error);
 
-    expect(await findFlowEntriesByCaptureSessionId("cs-1")).toBe(error);
+    expect(await findAllFlowEntries()).toBe(error);
   });
 
   it("propagates an error from the item retrieval", async () => {
@@ -148,7 +141,7 @@ describe("findFlowEntriesByCaptureSessionId", () => {
     vi.mocked(getAllSessionStorageKeys).mockResolvedValue([keyOf(flow)]);
     vi.mocked(getSessionStorageItems).mockResolvedValue(error);
 
-    expect(await findFlowEntriesByCaptureSessionId("cs-1")).toBe(error);
+    expect(await findAllFlowEntries()).toBe(error);
   });
 });
 

--- a/src/common/services/flow-store.ts
+++ b/src/common/services/flow-store.ts
@@ -20,10 +20,8 @@ export async function deleteFlowEntry(flowEntry: FlowEntry): Promise<void | Erro
   return await removeSessionStorageItems([makeFlowEntryKey(flowEntry)]);
 }
 
-export async function findFlowEntriesByCaptureSessionId(
-  captureSessionId: string,
-): Promise<FlowEntry[] | Error> {
-  const entries = await findFlowEntriesBy((e) => e.captureSessionId === captureSessionId);
+export async function findAllFlowEntries(): Promise<FlowEntry[] | Error> {
+  const entries = await findFlowEntriesBy(() => true);
   if (entries instanceof Error) {
     return entries;
   }

--- a/src/common/services/saml-recorder.test.ts
+++ b/src/common/services/saml-recorder.test.ts
@@ -76,7 +76,6 @@ describe("recordSamlTrace", () => {
   it("issues a flow for an unknown correlation key and stores the trace", async () => {
     const result = await recordSamlTrace(
       "cs-1",
-      1,
       { step: 6, correlationKey: "authn-req-1" },
       makeResponse(),
     );
@@ -99,7 +98,6 @@ describe("recordSamlTrace", () => {
 
     const result = await recordSamlTrace(
       "cs-1",
-      1,
       { step: 2, correlationKey: "authn-req-1" },
       makeResponse(),
       pairedHttpRequest,
@@ -120,7 +118,7 @@ describe("recordSamlTrace", () => {
   it("skips the step 1 trace when the paired request is missing", async () => {
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    await recordSamlTrace("cs-1", 1, { step: 2, correlationKey: "authn-req-1" }, makeResponse());
+    await recordSamlTrace("cs-1", { step: 2, correlationKey: "authn-req-1" }, makeResponse());
 
     expect(storedSamlTraces().map((t) => t.step)).toEqual([2]);
     expect(consoleWarn).toHaveBeenCalledOnce();
@@ -129,7 +127,6 @@ describe("recordSamlTrace", () => {
   it("does not issue a step 1 trace for steps other than 2", async () => {
     await recordSamlTrace(
       "cs-1",
-      1,
       { step: 6, correlationKey: "authn-req-1" },
       makeResponse(),
       makeRequest(),
@@ -143,7 +140,6 @@ describe("recordSamlTrace", () => {
 
     const result = await recordSamlTrace(
       "cs-1",
-      1,
       { step: 2, correlationKey: "authn-req-1" },
       makeResponse(),
       pairedHttpRequest,
@@ -155,16 +151,16 @@ describe("recordSamlTrace", () => {
 
   it("reuses the flow of the same correlation key", async () => {
     const detection = { step: 2, correlationKey: "authn-req-1" } as const;
-    await recordSamlTrace("cs-1", 1, detection, makeResponse(), makeRequest());
-    await recordSamlTrace("cs-1", 1, { step: 6, correlationKey: "authn-req-1" }, makeResponse());
+    await recordSamlTrace("cs-1", detection, makeResponse(), makeRequest());
+    await recordSamlTrace("cs-1", { step: 6, correlationKey: "authn-req-1" }, makeResponse());
 
     expect(storedFlowEntries()).toHaveLength(1);
   });
 
   it("issues a flow per capture session", async () => {
     const detection = { step: 2, correlationKey: "authn-req-1" } as const;
-    await recordSamlTrace("cs-1", 1, detection, makeResponse(), makeRequest());
-    await recordSamlTrace("cs-2", 1, detection, makeResponse(), makeRequest());
+    await recordSamlTrace("cs-1", detection, makeResponse(), makeRequest());
+    await recordSamlTrace("cs-2", detection, makeResponse(), makeRequest());
 
     expect(storedFlowEntries().map((f) => f.captureSessionId)).toEqual(["cs-1", "cs-2"]);
   });
@@ -174,7 +170,6 @@ describe("recordSamlTrace", () => {
 
     const result = await recordSamlTrace(
       "cs-1",
-      1,
       { step: 2, correlationKey: "authn-req-1" },
       httpResponse,
       makeRequest(),
@@ -189,7 +184,6 @@ describe("recordSamlTrace", () => {
 
     const result = await recordSamlTrace(
       "cs-1",
-      1,
       { step: 6, correlationKey: "authn-req-1" },
       makeResponse(),
     );

--- a/src/common/services/saml-recorder.ts
+++ b/src/common/services/saml-recorder.ts
@@ -12,7 +12,6 @@ import { saveSamlTrace } from "@/common/services/saml-store.ts";
 
 export async function recordSamlTrace(
   captureSessionId: string,
-  tabId: number,
   detection: SamlDetection,
   httpMessage: HttpMessage,
   pairedHttpRequest?: HttpRequest,
@@ -25,7 +24,6 @@ export async function recordSamlTrace(
     } else {
       const recordError = await recordSamlTrace(
         captureSessionId,
-        tabId,
         {
           step: 1,
           correlationKey: detection.correlationKey,
@@ -48,7 +46,7 @@ export async function recordSamlTrace(
     return samlTrace;
   }
 
-  const saveError = await saveSamlTrace(samlTrace, tabId);
+  const saveError = await saveSamlTrace(samlTrace);
   if (saveError) {
     return saveError;
   }

--- a/src/common/services/saml-store.test.ts
+++ b/src/common/services/saml-store.test.ts
@@ -55,28 +55,28 @@ function makeTrace(overrides: Record<string, unknown> = {}): SamlTrace {
 }
 
 describe("saveSamlTrace", () => {
-  it("stores the trace under a JSON key with id, kind, tabId, and flowId", async () => {
-    const result = await saveSamlTrace(makeTrace(), 1);
+  it("stores the trace under a JSON key of the ID, kind, and flow", async () => {
+    const result = await saveSamlTrace(makeTrace());
 
     expect(result).toBeUndefined();
     expect(storage).toEqual({
-      '{"id":"trace-1","kind":"trace","tabId":1,"flowId":"flow-1"}': makeTrace(),
+      '{"id":"trace-1","kind":"trace","flowId":"flow-1"}': makeTrace(),
     });
   });
 
   it("keeps traces of the same step as separate records", async () => {
-    await saveSamlTrace(makeTrace({ id: "trace-1", step: 2 }), 1);
-    await saveSamlTrace(makeTrace({ id: "trace-2", step: 2 }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-1", step: 2 }));
+    await saveSamlTrace(makeTrace({ id: "trace-2", step: 2 }));
 
     expect(await findSamlTracesByFlowId("flow-1")).toHaveLength(2);
   });
 });
 
 describe("findSamlTracesByFlowId", () => {
-  it("returns the traces of the flow across tabs in id order", async () => {
-    await saveSamlTrace(makeTrace({ id: "trace-2", flowId: "flow-1" }), 1);
-    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }), 2);
-    await saveSamlTrace(makeTrace({ id: "trace-3", flowId: "flow-2" }), 1);
+  it("returns the traces of the flow in id order", async () => {
+    await saveSamlTrace(makeTrace({ id: "trace-2", flowId: "flow-1" }));
+    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }));
+    await saveSamlTrace(makeTrace({ id: "trace-3", flowId: "flow-2" }));
 
     const result = await findSamlTracesByFlowId("flow-1");
 
@@ -85,13 +85,13 @@ describe("findSamlTracesByFlowId", () => {
   });
 
   it("reads only the items with matching keys", async () => {
-    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }), 1);
-    await saveSamlTrace(makeTrace({ id: "trace-2", flowId: "flow-2" }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }));
+    await saveSamlTrace(makeTrace({ id: "trace-2", flowId: "flow-2" }));
 
     await findSamlTracesByFlowId("flow-1");
 
     expect(getSessionStorageItems).toHaveBeenCalledWith([
-      '{"id":"trace-1","kind":"trace","tabId":1,"flowId":"flow-1"}',
+      '{"id":"trace-1","kind":"trace","flowId":"flow-1"}',
     ]);
   });
 
@@ -105,9 +105,9 @@ describe("findSamlTracesByFlowId", () => {
 
 describe("deleteSamlTracesByFlowId", () => {
   it("removes only the traces of the flow", async () => {
-    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }), 1);
-    await saveSamlTrace(makeTrace({ id: "trace-2", flowId: "flow-2" }), 1);
-    await saveSamlTrace(makeTrace({ id: "trace-3", flowId: "flow-1" }), 2);
+    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }));
+    await saveSamlTrace(makeTrace({ id: "trace-2", flowId: "flow-2" }));
+    await saveSamlTrace(makeTrace({ id: "trace-3", flowId: "flow-1" }));
 
     const result = await deleteSamlTracesByFlowId("flow-1");
 
@@ -129,7 +129,7 @@ describe("deleteSamlTracesByFlowId", () => {
 
   it("propagates an error from the removal", async () => {
     const error = new Error("storage error");
-    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }), 1);
+    await saveSamlTrace(makeTrace({ id: "trace-1", flowId: "flow-1" }));
     vi.mocked(removeSessionStorageItems).mockResolvedValue(error);
 
     expect(await deleteSamlTracesByFlowId("flow-1")).toBe(error);

--- a/src/common/services/saml-store.test.ts
+++ b/src/common/services/saml-store.test.ts
@@ -11,12 +11,7 @@ import {
   removeSessionStorageItems,
   setSessionStorageItem,
 } from "@/common/utils/chrome-storage.ts";
-import {
-  deleteSamlTracesByFlowId,
-  findSamlTracesByFlowId,
-  findSamlTracesByTabId,
-  saveSamlTrace,
-} from "./saml-store.ts";
+import { deleteSamlTracesByFlowId, findSamlTracesByFlowId, saveSamlTrace } from "./saml-store.ts";
 
 vi.mock("@/common/utils/chrome-storage.ts", () => ({
   getAllSessionStorageKeys: vi.fn(),
@@ -73,39 +68,7 @@ describe("saveSamlTrace", () => {
     await saveSamlTrace(makeTrace({ id: "trace-1", step: 2 }), 1);
     await saveSamlTrace(makeTrace({ id: "trace-2", step: 2 }), 1);
 
-    expect(await findSamlTracesByTabId(1)).toHaveLength(2);
-  });
-});
-
-describe("findSamlTracesByTabId", () => {
-  it("returns the traces of the tab in id order", async () => {
-    await saveSamlTrace(makeTrace({ id: "trace-2" }), 1);
-    await saveSamlTrace(makeTrace({ id: "trace-1" }), 1);
-    await saveSamlTrace(makeTrace({ id: "trace-3" }), 2);
-    storage["other-key"] = { some: "value" };
-
-    const result = await findSamlTracesByTabId(1);
-
-    expect(result).not.toBeInstanceOf(Error);
-    expect((result as SamlTrace[]).map((t) => t.id)).toEqual(["trace-1", "trace-2"]);
-  });
-
-  it("skips an invalid stored value with a warning", async () => {
-    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    storage['{"id":"trace-1","kind":"trace","tabId":1,"flowId":"flow-1"}'] = { broken: true };
-    await saveSamlTrace(makeTrace({ id: "trace-2" }), 1);
-
-    const result = await findSamlTracesByTabId(1);
-
-    expect((result as SamlTrace[]).map((t) => t.id)).toEqual(["trace-2"]);
-    expect(consoleWarn).toHaveBeenCalledOnce();
-  });
-
-  it("propagates an error from the storage", async () => {
-    const error = new Error("storage error");
-    vi.mocked(getAllSessionStorageKeys).mockResolvedValue(error);
-
-    expect(await findSamlTracesByTabId(1)).toBe(error);
+    expect(await findSamlTracesByFlowId("flow-1")).toHaveLength(2);
   });
 });
 
@@ -150,8 +113,10 @@ describe("deleteSamlTracesByFlowId", () => {
 
     expect(result).toBeUndefined();
     expect(getSessionStorageItems).not.toHaveBeenCalled();
-    expect(((await findSamlTracesByTabId(1)) as SamlTrace[]).map((t) => t.id)).toEqual(["trace-2"]);
-    expect(await findSamlTracesByTabId(2)).toEqual([]);
+    expect(((await findSamlTracesByFlowId("flow-2")) as SamlTrace[]).map((t) => t.id)).toEqual([
+      "trace-2",
+    ]);
+    expect(await findSamlTracesByFlowId("flow-1")).toEqual([]);
   });
 
   it("propagates an error from the key retrieval", async () => {

--- a/src/common/services/saml-store.ts
+++ b/src/common/services/saml-store.ts
@@ -25,10 +25,6 @@ export async function deleteSamlTracesByFlowId(flowId: string): Promise<void | E
   return await removeSessionStorageItems(keys);
 }
 
-export async function findSamlTracesByTabId(tabId: number): Promise<SamlTrace[] | Error> {
-  return await findSamlTracesBy((k) => k.tabId === tabId);
-}
-
 export async function findSamlTracesByFlowId(flowId: string): Promise<SamlTrace[] | Error> {
   return await findSamlTracesBy((k) => k.flowId === flowId);
 }

--- a/src/common/services/saml-store.ts
+++ b/src/common/services/saml-store.ts
@@ -12,8 +12,8 @@ import {
 } from "@/common/utils/chrome-storage.ts";
 import { isObject } from "@/common/utils/type-guard.ts";
 
-export async function saveSamlTrace(samlTrace: SamlTrace, tabId: number): Promise<void | Error> {
-  return await setSessionStorageItem(makeSamlTraceKey(samlTrace, tabId), samlTrace);
+export async function saveSamlTrace(samlTrace: SamlTrace): Promise<void | Error> {
+  return await setSessionStorageItem(makeSamlTraceKey(samlTrace), samlTrace);
 }
 
 export async function deleteSamlTracesByFlowId(flowId: string): Promise<void | Error> {
@@ -72,7 +72,6 @@ const samlTraceKind = "trace";
 type SamlTraceKeyFields = {
   id: string;
   kind: typeof samlTraceKind;
-  tabId: number;
   flowId: string;
 };
 
@@ -81,18 +80,12 @@ function isSamlTraceKeyFields(u: unknown): u is SamlTraceKeyFields {
     isObject(u) &&
     typeof u.id === "string" &&
     u.kind === samlTraceKind &&
-    typeof u.tabId === "number" &&
     typeof u.flowId === "string"
   );
 }
 
-function makeSamlTraceKey(samlTrace: SamlTrace, tabId: number): string {
-  return JSON.stringify({ ...samlTrace, kind: samlTraceKind, tabId }, [
-    "id",
-    "kind",
-    "tabId",
-    "flowId",
-  ]);
+function makeSamlTraceKey(samlTrace: SamlTrace): string {
+  return JSON.stringify({ ...samlTrace, kind: samlTraceKind }, ["id", "kind", "flowId"]);
 }
 
 function parseSamlTraceKey(key: string): SamlTraceKeyFields | undefined {

--- a/src/common/services/saml-summarizer.test.ts
+++ b/src/common/services/saml-summarizer.test.ts
@@ -66,7 +66,7 @@ describe("summarizeSamlFlow", () => {
 
     expect(result).toMatchObject({
       protocol: "saml",
-      sessionId: "corr-1",
+      sessionId: "flow-1",
       imported: false,
       capturing: false,
       start: "2026-01-01T00:00:00.000Z",
@@ -164,12 +164,12 @@ describe("summarizeSamlFlow", () => {
     expect(result).toMatchObject({ action: "third action" });
   });
 
-  it("uses the correlation key of the flow as the session ID", () => {
+  it("uses the flow ID as the session ID", () => {
     const result = summarizeSamlFlow(flowEntry, captureSession, [
       makeSamlTrace({ step: 2, type: "IncomingAuthnRequest" }),
     ]);
 
-    expect(result).toMatchObject({ sessionId: "corr-1", imported: false });
+    expect(result).toMatchObject({ sessionId: "flow-1", imported: false });
   });
 
   it("derives imported from the capture session", () => {

--- a/src/common/services/saml-summarizer.ts
+++ b/src/common/services/saml-summarizer.ts
@@ -17,7 +17,7 @@ export function summarizeSamlFlow(
     protocol: "saml",
     imported: captureSession.imported,
     capturing: false,
-    sessionId: flowEntry.correlationKey,
+    sessionId: flowEntry.id,
     warning: [],
   });
 }

--- a/src/common/services/session-archiver.test.ts
+++ b/src/common/services/session-archiver.test.ts
@@ -129,7 +129,6 @@ describe("loadSessionArchive", () => {
     expect(saveHttpMessage).toHaveBeenCalledWith(importedHttpMessage);
     expect(recordSamlTrace).toHaveBeenCalledWith(
       importedRecord.id,
-      1,
       { step: 3, correlationKey: "session-1" },
       importedHttpMessage,
       undefined,
@@ -200,7 +199,6 @@ describe("loadSessionArchive", () => {
     expect(saveHttpMessage).toHaveBeenNthCalledWith(2, importedHttpMessage);
     expect(recordSamlTrace).toHaveBeenCalledExactlyOnceWith(
       importedRecord.id,
-      1,
       { step: 6, correlationKey: "session-1" },
       importedHttpMessage,
       importedPairedRequest,

--- a/src/common/services/session-archiver.test.ts
+++ b/src/common/services/session-archiver.test.ts
@@ -8,10 +8,8 @@ import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { newHar, toHttpMessages } from "@/common/models/http-archive.ts";
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { saveEventRecord } from "@/common/services/event-store.ts";
-import {
-  findFlowEntryByCorrelationKeyInTab,
-  findHttpMessagesOfFlow,
-} from "@/common/services/flow-query.ts";
+import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import { findFlowEntryById } from "@/common/services/flow-store.ts";
 import { saveHttpMessage } from "@/common/services/http-store.ts";
 import {
   detectSamlStepFromHttpRequest,
@@ -30,8 +28,11 @@ vi.mock("@/common/services/event-store.ts", () => ({
 }));
 
 vi.mock("@/common/services/flow-query.ts", () => ({
-  findFlowEntryByCorrelationKeyInTab: vi.fn(),
   findHttpMessagesOfFlow: vi.fn(),
+}));
+
+vi.mock("@/common/services/flow-store.ts", () => ({
+  findFlowEntryById: vi.fn(),
 }));
 
 vi.mock("@/common/services/http-store.ts", () => ({
@@ -62,42 +63,42 @@ describe("dumpSessionArchive", () => {
 
   it("returns HAR string on success", async () => {
     const httpMessages = [{} as HttpMessage];
-    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(flowEntry);
+    vi.mocked(findFlowEntryById).mockResolvedValue(flowEntry);
     vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(httpMessages);
     vi.mocked(newHar).mockReturnValue('{"log":{}}');
 
-    const result = await dumpSessionArchive(1, "session-1");
+    const result = await dumpSessionArchive(1, "flow-1");
 
-    expect(findFlowEntryByCorrelationKeyInTab).toHaveBeenCalledWith(1, "session-1");
+    expect(findFlowEntryById).toHaveBeenCalledWith("flow-1");
     expect(findHttpMessagesOfFlow).toHaveBeenCalledWith("flow-1");
     expect(newHar).toHaveBeenCalledWith(httpMessages);
     expect(result).toBe('{"log":{}}');
   });
 
   it("returns Error when the flow cannot be found", async () => {
-    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(new Error("storage error"));
+    vi.mocked(findFlowEntryById).mockResolvedValue(new Error("storage error"));
 
-    const result = await dumpSessionArchive(1, "session-1");
+    const result = await dumpSessionArchive(1, "flow-1");
 
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("storage error");
     expect(findHttpMessagesOfFlow).not.toHaveBeenCalled();
   });
 
-  it("returns Error when no flow has the session ID", async () => {
-    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(undefined);
+  it("returns Error when no flow has the flow ID", async () => {
+    vi.mocked(findFlowEntryById).mockResolvedValue(undefined);
 
-    const result = await dumpSessionArchive(1, "session-1");
+    const result = await dumpSessionArchive(1, "flow-1");
 
     expect(result).toBeInstanceOf(Error);
     expect(findHttpMessagesOfFlow).not.toHaveBeenCalled();
   });
 
   it("returns Error when findHttpMessagesOfFlow fails", async () => {
-    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(flowEntry);
+    vi.mocked(findFlowEntryById).mockResolvedValue(flowEntry);
     vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(new Error("storage error"));
 
-    const result = await dumpSessionArchive(1, "session-1");
+    const result = await dumpSessionArchive(1, "flow-1");
 
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("storage error");

--- a/src/common/services/session-archiver.ts
+++ b/src/common/services/session-archiver.ts
@@ -49,11 +49,11 @@ export async function dumpSessionArchive(_tabId: number, flowId: string): Promis
  *
  * A single archive may contain multiple sessions.
  *
- * @param tabId - The tab ID to associate with imported sessions
+ * @param _tabId - Unused. Kept until the side panel stops passing it
  * @param har - The HAR JSON string to import
  * @returns An array of imported session IDs, or an Error if import fails
  */
-export async function loadSessionArchive(tabId: number, har: string): Promise<string[] | Error> {
+export async function loadSessionArchive(_tabId: number, har: string): Promise<string[] | Error> {
   const archivedHttpMessages = toHttpMessages(har);
   if (archivedHttpMessages instanceof Error) {
     return archivedHttpMessages;
@@ -107,7 +107,6 @@ export async function loadSessionArchive(tabId: number, har: string): Promise<st
 
     const recordError = await recordSamlTrace(
       captureSessionId,
-      tabId,
       detection,
       httpMessage,
       pairedHttpRequest,

--- a/src/common/services/session-archiver.ts
+++ b/src/common/services/session-archiver.ts
@@ -12,10 +12,8 @@ import {
 } from "@/common/models/http-message.ts";
 import { type SamlDetection } from "@/common/models/saml-detection.ts";
 import { saveEventRecord } from "@/common/services/event-store.ts";
-import {
-  findFlowEntryByCorrelationKeyInTab,
-  findHttpMessagesOfFlow,
-} from "@/common/services/flow-query.ts";
+import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import { findFlowEntryById } from "@/common/services/flow-store.ts";
 import { saveHttpMessage } from "@/common/services/http-store.ts";
 import {
   detectSamlStepFromHttpRequest,
@@ -24,17 +22,14 @@ import {
 import { recordSamlTrace } from "@/common/services/saml-recorder.ts";
 
 /**
- * Export session data as an HTTP Archive (HAR) JSON string.
+ * Export SSO flow data as an HTTP Archive (HAR) JSON string.
  *
- * @param tabId - The tab ID associated with the session
- * @param sessionId - The session ID to export
+ * @param _tabId - Unused. Kept until the side panel stops passing it
+ * @param flowId - The flow ID to export
  * @returns The HAR JSON string, or an Error if retrieval fails
  */
-export async function dumpSessionArchive(
-  tabId: number,
-  sessionId: string,
-): Promise<string | Error> {
-  const flowEntry = await findFlowEntryByCorrelationKeyInTab(tabId, sessionId);
+export async function dumpSessionArchive(_tabId: number, flowId: string): Promise<string | Error> {
+  const flowEntry = await findFlowEntryById(flowId);
   if (flowEntry instanceof Error) {
     return flowEntry;
   } else if (flowEntry === undefined) {

--- a/src/common/services/session-manager.test.ts
+++ b/src/common/services/session-manager.test.ts
@@ -8,25 +8,29 @@ import { type CaptureSession } from "@/common/models/capture-session.ts";
 import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
-import { getCaptureSession } from "@/common/services/capture-query.ts";
-import { findFlowEntriesByTabId, findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
-import { deleteFlowEntry, findFlowEntryById } from "@/common/services/flow-store.ts";
+import { getCaptureSessions, isCapturing } from "@/common/services/capture-query.ts";
+import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import {
+  deleteFlowEntry,
+  findAllFlowEntries,
+  findFlowEntryById,
+} from "@/common/services/flow-store.ts";
 import { deleteHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTracesByFlowId, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
-import { isWatching } from "@/common/services/watch-query.ts";
 import { deleteSession, getSessionSummaries } from "./session-manager.ts";
 
 vi.mock("@/common/services/capture-query.ts", () => ({
-  getCaptureSession: vi.fn(),
+  getCaptureSessions: vi.fn(),
+  isCapturing: vi.fn(),
 }));
 
 vi.mock("@/common/services/flow-query.ts", () => ({
-  findFlowEntriesByTabId: vi.fn(),
   findHttpMessagesOfFlow: vi.fn(),
 }));
 
 vi.mock("@/common/services/flow-store.ts", () => ({
   deleteFlowEntry: vi.fn(),
+  findAllFlowEntries: vi.fn(),
   findFlowEntryById: vi.fn(),
 }));
 
@@ -39,17 +43,13 @@ vi.mock("@/common/services/saml-store.ts", () => ({
   findSamlTracesByFlowId: vi.fn(),
 }));
 
-vi.mock("@/common/services/watch-query.ts", () => ({
-  isWatching: vi.fn(),
-}));
-
 beforeEach(() => {
   vi.resetAllMocks();
 
-  vi.mocked(findFlowEntriesByTabId).mockResolvedValue([]);
-  vi.mocked(getCaptureSession).mockResolvedValue(undefined);
+  vi.mocked(getCaptureSessions).mockResolvedValue([]);
+  vi.mocked(isCapturing).mockResolvedValue(false);
+  vi.mocked(findAllFlowEntries).mockResolvedValue([]);
   vi.mocked(findSamlTracesByFlowId).mockResolvedValue([]);
-  vi.mocked(isWatching).mockResolvedValue(false);
   vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
   vi.mocked(findHttpMessagesOfFlow).mockResolvedValue([]);
   vi.mocked(deleteSamlTracesByFlowId).mockResolvedValue(undefined);
@@ -100,16 +100,19 @@ function makeCaptureSession(overrides: Partial<CaptureSession> = {}): CaptureSes
 //
 
 describe("getSessionSummaries", () => {
-  it("returns an empty array when no flows exist", async () => {
+  it("returns an empty array when no capture session exists", async () => {
     expect(await getSessionSummaries(1)).toEqual([]);
   });
 
   it("builds one summary per flow in the given order", async () => {
-    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([
-      makeFlowEntry({ id: "flow-2", correlationKey: "corr-2" }),
+    vi.mocked(getCaptureSessions).mockResolvedValue([
+      makeCaptureSession({ id: "cs-2" }),
+      makeCaptureSession({ id: "cs-1" }),
+    ]);
+    vi.mocked(findAllFlowEntries).mockResolvedValue([
+      makeFlowEntry({ id: "flow-2", captureSessionId: "cs-2", correlationKey: "corr-2" }),
       makeFlowEntry({ id: "flow-1", correlationKey: "corr-1" }),
     ]);
-    vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession());
     vi.mocked(findSamlTracesByFlowId).mockImplementation(async (flowId) =>
       flowId === "flow-1"
         ? [
@@ -129,80 +132,103 @@ describe("getSessionSummaries", () => {
   });
 
   it("derives imported from the capture session", async () => {
-    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
-    vi.mocked(getCaptureSession).mockResolvedValue(
+    vi.mocked(getCaptureSessions).mockResolvedValue([
       makeCaptureSession({ imported: true, importedAt: "2026-01-01T00:00:00Z" }),
-    );
+    ]);
+    vi.mocked(findAllFlowEntries).mockResolvedValue([makeFlowEntry()]);
     vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
 
-    const result = await getSessionSummaries(1);
-
-    expect(result).toMatchObject([{ imported: true, capturing: false }]);
+    expect(await getSessionSummaries(1)).toMatchObject([{ imported: true, capturing: false }]);
   });
 
-  it("sets capturing when the capture session is ongoing and the tab is watched", async () => {
-    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
-    vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession({ endedAt: undefined }));
+  it("sets capturing on the newest flow of the ongoing capture session", async () => {
+    vi.mocked(getCaptureSessions).mockResolvedValue([makeCaptureSession({ endedAt: undefined })]);
+    vi.mocked(findAllFlowEntries).mockResolvedValue([
+      makeFlowEntry({ id: "flow-2", correlationKey: "corr-2" }),
+      makeFlowEntry({ id: "flow-1", correlationKey: "corr-1" }),
+    ]);
     vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
-    vi.mocked(isWatching).mockResolvedValue(true);
+    vi.mocked(isCapturing).mockResolvedValue(true);
 
-    expect(await getSessionSummaries(1)).toMatchObject([{ capturing: true }]);
+    expect(await getSessionSummaries(1)).toMatchObject([
+      { sessionId: "flow-2", capturing: true },
+      { sessionId: "flow-1", capturing: false },
+    ]);
+  });
+
+  it("sets capturing on the newest flow of the ongoing capture session, not of an import", async () => {
+    vi.mocked(getCaptureSessions).mockResolvedValue([
+      makeCaptureSession({ id: "cs-2", imported: true, importedAt: "2026-01-01T00:02:00Z" }),
+      makeCaptureSession({ id: "cs-1", endedAt: undefined }),
+    ]);
+    vi.mocked(findAllFlowEntries).mockResolvedValue([
+      makeFlowEntry({ id: "flow-2", captureSessionId: "cs-2", correlationKey: "corr-2" }),
+      makeFlowEntry({ id: "flow-1", correlationKey: "corr-1" }),
+    ]);
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
+    vi.mocked(isCapturing).mockResolvedValue(true);
+
+    expect(await getSessionSummaries(1)).toMatchObject([
+      { sessionId: "flow-2", capturing: false },
+      { sessionId: "flow-1", capturing: true },
+    ]);
   });
 
   it("does not set capturing when the capture session has ended", async () => {
-    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
-    vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession());
+    vi.mocked(getCaptureSessions).mockResolvedValue([makeCaptureSession()]);
+    vi.mocked(findAllFlowEntries).mockResolvedValue([makeFlowEntry()]);
     vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
-    vi.mocked(isWatching).mockResolvedValue(true);
+    vi.mocked(isCapturing).mockResolvedValue(true);
 
     expect(await getSessionSummaries(1)).toMatchObject([{ capturing: false }]);
   });
 
-  it("does not set capturing when the tab is not watched", async () => {
-    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
-    vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession({ endedAt: undefined }));
+  it("does not set capturing when no capture is running", async () => {
+    vi.mocked(getCaptureSessions).mockResolvedValue([makeCaptureSession({ endedAt: undefined })]);
+    vi.mocked(findAllFlowEntries).mockResolvedValue([makeFlowEntry()]);
     vi.mocked(findSamlTracesByFlowId).mockResolvedValue([makeSamlTrace({})]);
-    vi.mocked(isWatching).mockResolvedValue(false);
+    vi.mocked(isCapturing).mockResolvedValue(false);
 
     expect(await getSessionSummaries(1)).toMatchObject([{ capturing: false }]);
-  });
-
-  it("propagates an error from the flow query", async () => {
-    const error = new Error("flow query error");
-    vi.mocked(findFlowEntriesByTabId).mockResolvedValue(error);
-
-    expect(await getSessionSummaries(1)).toBe(error);
-  });
-
-  it("propagates an error from the capture session query", async () => {
-    const error = new Error("capture query error");
-    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
-    vi.mocked(getCaptureSession).mockResolvedValue(error);
-
-    expect(await getSessionSummaries(1)).toBe(error);
-  });
-
-  it("propagates an error from the trace store", async () => {
-    const error = new Error("trace store error");
-    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
-    vi.mocked(getCaptureSession).mockResolvedValue(makeCaptureSession());
-    vi.mocked(findSamlTracesByFlowId).mockResolvedValue(error);
-
-    expect(await getSessionSummaries(1)).toBe(error);
   });
 
   it("skips a flow whose capture session is missing with a warning", async () => {
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.mocked(findFlowEntriesByTabId).mockResolvedValue([makeFlowEntry()]);
+    vi.mocked(getCaptureSessions).mockResolvedValue([makeCaptureSession({ id: "cs-2" })]);
+    vi.mocked(findAllFlowEntries).mockResolvedValue([makeFlowEntry()]);
 
     expect(await getSessionSummaries(1)).toEqual([]);
     expect(consoleWarn).toHaveBeenCalledOnce();
     expect(findSamlTracesByFlowId).not.toHaveBeenCalled();
   });
 
-  it("propagates an error from the watch query", async () => {
-    const error = new Error("watch query error");
-    vi.mocked(isWatching).mockResolvedValue(error);
+  it("propagates an error from the capturing state", async () => {
+    const error = new Error("capture query error");
+    vi.mocked(isCapturing).mockResolvedValue(error);
+
+    expect(await getSessionSummaries(1)).toBe(error);
+  });
+
+  it("propagates an error from the capture session query", async () => {
+    const error = new Error("capture query error");
+    vi.mocked(getCaptureSessions).mockResolvedValue(error);
+
+    expect(await getSessionSummaries(1)).toBe(error);
+  });
+
+  it("propagates an error from the flow store", async () => {
+    const error = new Error("flow store error");
+    vi.mocked(getCaptureSessions).mockResolvedValue([makeCaptureSession()]);
+    vi.mocked(findAllFlowEntries).mockResolvedValue(error);
+
+    expect(await getSessionSummaries(1)).toBe(error);
+  });
+
+  it("propagates an error from the trace store", async () => {
+    const error = new Error("trace store error");
+    vi.mocked(getCaptureSessions).mockResolvedValue([makeCaptureSession()]);
+    vi.mocked(findAllFlowEntries).mockResolvedValue([makeFlowEntry()]);
+    vi.mocked(findSamlTracesByFlowId).mockResolvedValue(error);
 
     expect(await getSessionSummaries(1)).toBe(error);
   });

--- a/src/common/services/session-manager.test.ts
+++ b/src/common/services/session-manager.test.ts
@@ -9,12 +9,8 @@ import { type FlowEntry } from "@/common/models/flow-entry.ts";
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { getCaptureSession } from "@/common/services/capture-query.ts";
-import {
-  findFlowEntriesByTabId,
-  findFlowEntryByCorrelationKeyInTab,
-  findHttpMessagesOfFlow,
-} from "@/common/services/flow-query.ts";
-import { deleteFlowEntry } from "@/common/services/flow-store.ts";
+import { findFlowEntriesByTabId, findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import { deleteFlowEntry, findFlowEntryById } from "@/common/services/flow-store.ts";
 import { deleteHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTracesByFlowId, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 import { isWatching } from "@/common/services/watch-query.ts";
@@ -26,12 +22,12 @@ vi.mock("@/common/services/capture-query.ts", () => ({
 
 vi.mock("@/common/services/flow-query.ts", () => ({
   findFlowEntriesByTabId: vi.fn(),
-  findFlowEntryByCorrelationKeyInTab: vi.fn(),
   findHttpMessagesOfFlow: vi.fn(),
 }));
 
 vi.mock("@/common/services/flow-store.ts", () => ({
   deleteFlowEntry: vi.fn(),
+  findFlowEntryById: vi.fn(),
 }));
 
 vi.mock("@/common/services/http-store.ts", () => ({
@@ -54,7 +50,7 @@ beforeEach(() => {
   vi.mocked(getCaptureSession).mockResolvedValue(undefined);
   vi.mocked(findSamlTracesByFlowId).mockResolvedValue([]);
   vi.mocked(isWatching).mockResolvedValue(false);
-  vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(makeFlowEntry());
+  vi.mocked(findFlowEntryById).mockResolvedValue(makeFlowEntry());
   vi.mocked(findHttpMessagesOfFlow).mockResolvedValue([]);
   vi.mocked(deleteSamlTracesByFlowId).mockResolvedValue(undefined);
   vi.mocked(deleteFlowEntry).mockResolvedValue(undefined);
@@ -127,8 +123,8 @@ describe("getSessionSummaries", () => {
 
     expect(result).not.toBeInstanceOf(Error);
     expect(result).toMatchObject([
-      { sessionId: "corr-2", action: "other action" },
-      { sessionId: "corr-1", action: "second action" },
+      { sessionId: "flow-2", action: "other action" },
+      { sessionId: "flow-1", action: "second action" },
     ]);
   });
 
@@ -218,8 +214,8 @@ describe("deleteSession", () => {
     const httpMessages = [{ id: "msg-1" } as HttpMessage];
     vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(httpMessages);
 
-    expect(await deleteSession(1, "corr-1")).toBeUndefined();
-    expect(findFlowEntryByCorrelationKeyInTab).toHaveBeenCalledWith(1, "corr-1");
+    expect(await deleteSession(1, "flow-1")).toBeUndefined();
+    expect(findFlowEntryById).toHaveBeenCalledWith("flow-1");
     expect(findHttpMessagesOfFlow).toHaveBeenCalledWith("flow-1");
     expect(deleteSamlTracesByFlowId).toHaveBeenCalledWith("flow-1");
     expect(deleteFlowEntry).toHaveBeenCalledWith(flowEntry);
@@ -230,11 +226,11 @@ describe("deleteSession", () => {
     expect(order).toEqual(order.toSorted((a, b) => a - b));
   });
 
-  it("does nothing with a warning when no flow has the session ID", async () => {
+  it("does nothing with a warning when no flow has the flow ID", async () => {
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(undefined);
+    vi.mocked(findFlowEntryById).mockResolvedValue(undefined);
 
-    expect(await deleteSession(1, "corr-1")).toBeUndefined();
+    expect(await deleteSession(1, "flow-1")).toBeUndefined();
     expect(consoleWarn).toHaveBeenCalledOnce();
     expect(deleteSamlTracesByFlowId).not.toHaveBeenCalled();
     expect(deleteHttpMessages).not.toHaveBeenCalled();
@@ -242,9 +238,9 @@ describe("deleteSession", () => {
 
   it("returns an error when the flow cannot be found", async () => {
     const error = new Error("flow query error");
-    vi.mocked(findFlowEntryByCorrelationKeyInTab).mockResolvedValue(error);
+    vi.mocked(findFlowEntryById).mockResolvedValue(error);
 
-    expect(await deleteSession(1, "corr-1")).toBe(error);
+    expect(await deleteSession(1, "flow-1")).toBe(error);
     expect(deleteSamlTracesByFlowId).not.toHaveBeenCalled();
   });
 
@@ -252,7 +248,7 @@ describe("deleteSession", () => {
     const error = new Error("query error");
     vi.mocked(findHttpMessagesOfFlow).mockResolvedValue(error);
 
-    expect(await deleteSession(1, "corr-1")).toBe(error);
+    expect(await deleteSession(1, "flow-1")).toBe(error);
     expect(deleteSamlTracesByFlowId).not.toHaveBeenCalled();
     expect(deleteHttpMessages).not.toHaveBeenCalled();
   });
@@ -261,7 +257,7 @@ describe("deleteSession", () => {
     const error = new Error("saml delete error");
     vi.mocked(deleteSamlTracesByFlowId).mockResolvedValue(error);
 
-    expect(await deleteSession(1, "corr-1")).toBe(error);
+    expect(await deleteSession(1, "flow-1")).toBe(error);
     expect(deleteFlowEntry).not.toHaveBeenCalled();
     expect(deleteHttpMessages).not.toHaveBeenCalled();
   });
@@ -270,7 +266,7 @@ describe("deleteSession", () => {
     const error = new Error("flow delete error");
     vi.mocked(deleteFlowEntry).mockResolvedValue(error);
 
-    expect(await deleteSession(1, "corr-1")).toBe(error);
+    expect(await deleteSession(1, "flow-1")).toBe(error);
     expect(deleteHttpMessages).not.toHaveBeenCalled();
   });
 
@@ -278,7 +274,7 @@ describe("deleteSession", () => {
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.mocked(deleteHttpMessages).mockResolvedValue(new Error("http delete error"));
 
-    expect(await deleteSession(1, "corr-1")).toBeUndefined();
+    expect(await deleteSession(1, "flow-1")).toBeUndefined();
     expect(consoleWarn).toHaveBeenCalledOnce();
   });
 });

--- a/src/common/services/session-manager.ts
+++ b/src/common/services/session-manager.ts
@@ -3,43 +3,54 @@
  * @license BSD-3-Clause
  */
 
-import { type CaptureSession } from "@/common/models/capture-session.ts";
 import { type SessionSummary, debugSessionSummary } from "@/common/models/session-summary.ts";
-import { getCaptureSession } from "@/common/services/capture-query.ts";
-import { findFlowEntriesByTabId, findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
-import { deleteFlowEntry, findFlowEntryById } from "@/common/services/flow-store.ts";
+import { getCaptureSessions, isCapturing } from "@/common/services/capture-query.ts";
+import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import {
+  deleteFlowEntry,
+  findAllFlowEntries,
+  findFlowEntryById,
+} from "@/common/services/flow-store.ts";
 import { deleteHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTracesByFlowId, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 import { summarizeSamlFlow } from "@/common/services/saml-summarizer.ts";
-import { isWatching } from "@/common/services/watch-query.ts";
 
 // NOTE: getSessionSummaries has known inefficiencies (e.g., repeated data
 // fetches), but we prioritize simplicity as performance is not a concern at
 // current scale.
 
 /**
- * Retrieve summaries for all sessions associated with a tab.
+ * Retrieve a summary of every flow in every capture session.
  *
- * @param tabId - The tab ID to retrieve session summaries for
- * @returns An array of session summaries sorted by flow ID in descending order, or an Error
+ * @param _tabId - Unused. Kept until the side panel stops passing it
+ * @returns Flow summaries, newest first, or an Error
  */
-export async function getSessionSummaries(tabId: number): Promise<SessionSummary[] | Error> {
-  const watching = await isWatching(tabId);
-  if (watching instanceof Error) {
-    return watching;
+export async function getSessionSummaries(_tabId: number): Promise<SessionSummary[] | Error> {
+  const capturing = await isCapturing();
+  if (capturing instanceof Error) {
+    return capturing;
   }
 
-  const flowEntries = await findFlowEntriesByTabId(tabId);
+  const captureSessions = await getCaptureSessions();
+  if (captureSessions instanceof Error) {
+    return captureSessions;
+  }
+
+  const flowEntries = await findAllFlowEntries();
   if (flowEntries instanceof Error) {
     return flowEntries;
   }
 
+  const ongoingCaptureSession = captureSessions.find((s) => !s.imported && s.endedAt === undefined);
+  const ongoingFlowId =
+    ongoingCaptureSession !== undefined
+      ? flowEntries.find((f) => f.captureSessionId === ongoingCaptureSession.id)?.id
+      : undefined;
+
   const summaries: SessionSummary[] = [];
   for (const flowEntry of flowEntries) {
-    const captureSession = await getCaptureSession(flowEntry.captureSessionId);
-    if (captureSession instanceof Error) {
-      return captureSession;
-    } else if (captureSession === undefined) {
+    const captureSession = captureSessions.find((s) => s.id === flowEntry.captureSessionId);
+    if (captureSession === undefined) {
       console.warn("No capture session for the flow:", { flowId: flowEntry.id });
       continue;
     }
@@ -51,7 +62,7 @@ export async function getSessionSummaries(tabId: number): Promise<SessionSummary
 
     const summary = {
       ...summarizeSamlFlow(flowEntry, captureSession, samlTraces),
-      capturing: isOngoing(captureSession) && watching,
+      capturing: flowEntry.id === ongoingFlowId && capturing,
     };
 
     summaries.push(summary);
@@ -59,10 +70,6 @@ export async function getSessionSummaries(tabId: number): Promise<SessionSummary
   }
 
   return summaries;
-}
-
-function isOngoing(captureSession: CaptureSession): boolean {
-  return !captureSession.imported && captureSession.endedAt === undefined;
 }
 
 /**

--- a/src/common/services/session-manager.ts
+++ b/src/common/services/session-manager.ts
@@ -6,12 +6,8 @@
 import { type CaptureSession } from "@/common/models/capture-session.ts";
 import { type SessionSummary, debugSessionSummary } from "@/common/models/session-summary.ts";
 import { getCaptureSession } from "@/common/services/capture-query.ts";
-import {
-  findFlowEntriesByTabId,
-  findFlowEntryByCorrelationKeyInTab,
-  findHttpMessagesOfFlow,
-} from "@/common/services/flow-query.ts";
-import { deleteFlowEntry } from "@/common/services/flow-store.ts";
+import { findFlowEntriesByTabId, findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import { deleteFlowEntry, findFlowEntryById } from "@/common/services/flow-store.ts";
 import { deleteHttpMessages } from "@/common/services/http-store.ts";
 import { deleteSamlTracesByFlowId, findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 import { summarizeSamlFlow } from "@/common/services/saml-summarizer.ts";
@@ -70,18 +66,18 @@ function isOngoing(captureSession: CaptureSession): boolean {
 }
 
 /**
- * Delete all data for a specific session.
+ * Delete all data for a specific SSO flow.
  *
- * @param tabId - The tab ID associated with the session
- * @param sessionId - The session ID to delete
+ * @param _tabId - Unused. Kept until the side panel stops passing it
+ * @param flowId - The flow ID to delete
  * @returns void on success, or an Error
  */
-export async function deleteSession(tabId: number, sessionId: string): Promise<void | Error> {
-  const flowEntry = await findFlowEntryByCorrelationKeyInTab(tabId, sessionId);
+export async function deleteSession(_tabId: number, flowId: string): Promise<void | Error> {
+  const flowEntry = await findFlowEntryById(flowId);
   if (flowEntry instanceof Error) {
     return flowEntry;
   } else if (flowEntry === undefined) {
-    console.warn("No flow to delete:", { tabId, sessionId });
+    console.warn("No flow to delete:", { flowId });
     return;
   }
 

--- a/src/report-page/app-builders.ts
+++ b/src/report-page/app-builders.ts
@@ -6,10 +6,8 @@
 import { type HttpMessage } from "@/common/models/http-message.ts";
 import { type SamlTrace } from "@/common/models/saml-trace.ts";
 import { getCaptureSession } from "@/common/services/capture-query.ts";
-import {
-  findFlowEntryByCorrelationKeyInTab,
-  findHttpMessagesOfFlow,
-} from "@/common/services/flow-query.ts";
+import { findHttpMessagesOfFlow } from "@/common/services/flow-query.ts";
+import { findFlowEntryById } from "@/common/services/flow-store.ts";
 import {
   extractSamlAuthnRequestXml,
   extractSamlResponseXml,
@@ -17,21 +15,18 @@ import {
 import { findSamlTracesByFlowId } from "@/common/services/saml-store.ts";
 import { type FlowData } from "@/report-page/common/types.ts";
 
-export async function loadFlowData(
-  tabId: number,
-  sessionId: string | null,
-): Promise<FlowData | Error> {
-  if (!Number.isSafeInteger(tabId) || tabId <= 0 || sessionId === null) {
+export async function loadFlowData(flowId: string | null): Promise<FlowData | Error> {
+  if (flowId === null) {
     // In development mode, fall back to sample data
     if (import.meta.env.MODE === "development") {
       const { buildSampleFlowData } = await import("@/report-page/dev/sample-flow.ts");
       return buildSampleFlowData();
     } else {
-      return new Error(`Invalid URL params: tabId=${tabId}, sessionId=${sessionId}`);
+      return new Error("Invalid URL params");
     }
   }
 
-  const flowEntry = await findFlowEntryByCorrelationKeyInTab(tabId, sessionId);
+  const flowEntry = await findFlowEntryById(flowId);
   if (flowEntry instanceof Error) {
     return flowEntry;
   } else if (flowEntry === undefined) {

--- a/src/report-page/app.tsx
+++ b/src/report-page/app.tsx
@@ -31,10 +31,9 @@ export function App() {
   useEffect(() => {
     const fetchSessionData = async () => {
       const params = new URLSearchParams(window.location.search);
-      const tabId = Number(params.get("tabId"));
-      const sessionId = params.get("sessionId");
+      const flowId = params.get("sessionId");
 
-      const flowData = await loadFlowData(tabId, sessionId);
+      const flowData = await loadFlowData(flowId);
       if (flowData instanceof Error) {
         console.warn("Failed to load flow data:", { error: flowData });
         return;

--- a/src/report-page/content/content-builders.test.ts
+++ b/src/report-page/content/content-builders.test.ts
@@ -133,7 +133,6 @@ const sampleResponseXml = `
 describe("buildSessionData", () => {
   it("maps sessionSummary fields", () => {
     const summary = makeSessionSummary({
-      sessionId: "ses-abc",
       start: "2026-01-01T00:00:00Z",
       end: "2026-01-01T00:01:00Z",
       sp: "sp.example.com",
@@ -142,7 +141,6 @@ describe("buildSessionData", () => {
 
     const result = buildSessionData(summary);
 
-    expect(result.sessionId).toBe("ses-abc");
     expect(result.sessionStartTime).toBe("2026-01-01T00:00:00Z");
     expect(result.sessionEndTime).toBe("2026-01-01T00:01:00Z");
     expect(result.serviceProvider).toBe("sp.example.com");

--- a/src/report-page/content/content-builders.ts
+++ b/src/report-page/content/content-builders.ts
@@ -14,7 +14,6 @@ import { getHttpStatusText } from "@/report-page/common/utils.ts";
 //
 
 type SessionData = {
-  sessionId: string;
   sessionStartTime: string;
   sessionEndTime: string;
   serviceProvider: string;
@@ -81,7 +80,6 @@ export function buildSessionData(
   })();
 
   return {
-    sessionId: sessionSummary.sessionId,
     sessionStartTime: sessionSummary.start ?? "N/A",
     sessionEndTime: sessionSummary.end ?? "N/A",
     serviceProvider: sessionSummary.sp ?? "N/A",

--- a/src/report-page/content/session-overview.tsx
+++ b/src/report-page/content/session-overview.tsx
@@ -49,10 +49,6 @@ export function SessionOverview({
           <table className="w-full border-collapse">
             <tbody>
               <tr className="border-b border-gray-800 even:bg-gray-800/80">
-                <td className="w-1/3 px-4 py-3 font-semibold text-gray-300">Session ID</td>
-                <td className="px-4 py-3">{sessionData.sessionId}</td>
-              </tr>
-              <tr className="border-b border-gray-800 even:bg-gray-800/80">
                 <td className="w-1/3 px-4 py-3 font-semibold text-gray-300">Session Start Time</td>
                 <td className="px-4 py-3">{sessionData.sessionStartTime}</td>
               </tr>

--- a/src/service-worker/capture-manager.test.ts
+++ b/src/service-worker/capture-manager.test.ts
@@ -8,7 +8,6 @@ import {
   type EventRecord,
   newCaptureStartedRecord,
   newCaptureStoppedRecord,
-  newWatchStartedRecord,
 } from "@/common/models/event-record.ts";
 import { findAllEventRecords, saveEventRecord } from "@/common/services/event-store.ts";
 import { getWatchedTabIds } from "@/common/services/watch-query.ts";
@@ -17,13 +16,7 @@ import {
   startWatching,
   stopWatching,
 } from "@/service-worker/tab-watcher.ts";
-import {
-  getOngoingCaptureSessionId,
-  isCapturing,
-  registerCaptureStopHandler,
-  startCapturing,
-  stopCapturing,
-} from "./capture-manager.ts";
+import { registerCaptureStopHandler, startCapturing, stopCapturing } from "./capture-manager.ts";
 
 vi.mock("@/common/services/event-store.ts", () => ({
   findAllEventRecords: vi.fn(),
@@ -210,96 +203,5 @@ describe("registerCaptureStopHandler", () => {
 
     expect(onCaptureStopped).toHaveBeenCalledExactlyOnceWith(1);
     expect(console.warn).toHaveBeenCalled();
-  });
-});
-
-describe("getOngoingCaptureSessionId", () => {
-  it("returns the ID of the record that started the ongoing capture", async () => {
-    const records = captureRecords("CaptureStarted", "CaptureStopped", "CaptureStarted");
-    vi.mocked(findAllEventRecords).mockResolvedValue(records);
-
-    expect(await getOngoingCaptureSessionId()).toBe(records[2]?.id);
-    expect(getWatchedTabIds).not.toHaveBeenCalled();
-  });
-
-  it("ignores records other than capture records", async () => {
-    const records = [...captureRecords("CaptureStarted"), newWatchStartedRecord(1)];
-    vi.mocked(findAllEventRecords).mockResolvedValue(records);
-
-    expect(await getOngoingCaptureSessionId()).toBe(records[0]?.id);
-  });
-
-  it("returns undefined when the latest capture has stopped", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue(
-      captureRecords("CaptureStarted", "CaptureStopped"),
-    );
-
-    expect(await getOngoingCaptureSessionId()).toBeUndefined();
-  });
-
-  it("returns undefined when no capture has started", async () => {
-    expect(await getOngoingCaptureSessionId()).toBeUndefined();
-  });
-
-  it("returns the error when the records cannot be retrieved", async () => {
-    const error = new Error("storage failed");
-    vi.mocked(findAllEventRecords).mockResolvedValue(error);
-
-    expect(await getOngoingCaptureSessionId()).toBe(error);
-  });
-});
-
-describe("isCapturing", () => {
-  it("returns true when a capture has started and a tab is still watched", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue(captureRecords("CaptureStarted"));
-    vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
-
-    expect(await isCapturing()).toBe(true);
-  });
-
-  it("returns false when the latest capture has stopped", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue(
-      captureRecords("CaptureStarted", "CaptureStopped"),
-    );
-    vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
-
-    expect(await isCapturing()).toBe(false);
-    expect(getWatchedTabIds).not.toHaveBeenCalled();
-  });
-
-  it("returns true when a capture has started again after stopping", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue(
-      captureRecords("CaptureStarted", "CaptureStopped", "CaptureStarted"),
-    );
-    vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
-
-    expect(await isCapturing()).toBe(true);
-  });
-
-  it("returns false when no capture has started", async () => {
-    vi.mocked(getWatchedTabIds).mockResolvedValue([1]);
-
-    expect(await isCapturing()).toBe(false);
-  });
-
-  it("returns false when no tab is watched even though the capture is left open", async () => {
-    vi.mocked(findAllEventRecords).mockResolvedValue(captureRecords("CaptureStarted"));
-
-    expect(await isCapturing()).toBe(false);
-  });
-
-  it("returns the error when the records cannot be retrieved", async () => {
-    const error = new Error("storage failed");
-    vi.mocked(findAllEventRecords).mockResolvedValue(error);
-
-    expect(await isCapturing()).toBe(error);
-  });
-
-  it("returns the error when the watched tabs cannot be determined", async () => {
-    const error = new Error("targets failed");
-    vi.mocked(findAllEventRecords).mockResolvedValue(captureRecords("CaptureStarted"));
-    vi.mocked(getWatchedTabIds).mockResolvedValue(error);
-
-    expect(await isCapturing()).toBe(error);
   });
 });

--- a/src/service-worker/capture-manager.ts
+++ b/src/service-worker/capture-manager.ts
@@ -4,7 +4,8 @@
  */
 
 import { newCaptureStartedRecord, newCaptureStoppedRecord } from "@/common/models/event-record.ts";
-import { findAllEventRecords, saveEventRecord } from "@/common/services/event-store.ts";
+import { getOngoingCaptureSessionId, isCapturing } from "@/common/services/capture-query.ts";
+import { saveEventRecord } from "@/common/services/event-store.ts";
 import { getWatchedTabIds } from "@/common/services/watch-query.ts";
 import {
   registerWatchStopHandler,
@@ -23,47 +24,6 @@ export function registerCaptureStopHandler(
 
     await onCaptureStopped(tabId);
   });
-}
-
-export async function getOngoingCaptureSessionId(): Promise<string | undefined | Error> {
-  const records = await findAllEventRecords();
-  if (records instanceof Error) {
-    return records;
-  }
-
-  const latest = records
-    .filter((r) => r.type === "CaptureStarted" || r.type === "CaptureStopped")
-    .at(-1);
-  return latest?.type === "CaptureStarted" ? latest.id : undefined;
-}
-
-export async function isCapturing(): Promise<boolean | Error> {
-  // How the capture record and the watched tabs decide the result:
-  //
-  //   record | watched tab | result
-  //   -------+-------------+-------
-  //   open   | yes         | capturing
-  //   open   | no          | not capturing -- the stop record was lost [1]
-  //   closed | yes         | not capturing -- the record wins [2]
-  //   closed | no          | not capturing
-  //
-  // [1] The debugger is already detached, so staying "capturing" would show a recording that can
-  //     never be stopped.
-  // [2] The user can detach from the banner.
-
-  const sessionId = await getOngoingCaptureSessionId();
-  if (sessionId instanceof Error) {
-    return sessionId;
-  } else if (sessionId === undefined) {
-    return false;
-  }
-
-  const tabIds = await getWatchedTabIds();
-  if (tabIds instanceof Error) {
-    return tabIds;
-  }
-
-  return 0 < tabIds.length;
 }
 
 export async function startCapturing(tabId: number): Promise<void | Error> {

--- a/src/service-worker/http-interception.test.ts
+++ b/src/service-worker/http-interception.test.ts
@@ -6,16 +6,16 @@
 import type Protocol from "devtools-protocol";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type HttpRequest } from "@/common/models/http-message.ts";
+import { getOngoingCaptureSessionId } from "@/common/services/capture-query.ts";
 import { findHttpRequestByFetchRequestId } from "@/common/services/http-store.ts";
-import { getOngoingCaptureSessionId } from "@/service-worker/capture-manager.ts";
 import { registerHttpInterceptionHandlers } from "./http-interception.ts";
+
+vi.mock("@/common/services/capture-query.ts", () => ({
+  getOngoingCaptureSessionId: vi.fn(),
+}));
 
 vi.mock("@/common/services/http-store.ts", () => ({
   findHttpRequestByFetchRequestId: vi.fn(),
-}));
-
-vi.mock("@/service-worker/capture-manager.ts", () => ({
-  getOngoingCaptureSessionId: vi.fn(),
 }));
 
 //

--- a/src/service-worker/http-interception.ts
+++ b/src/service-worker/http-interception.ts
@@ -10,9 +10,9 @@ import {
   newHttpRequest,
   newHttpResponse,
 } from "@/common/models/http-message.ts";
+import { getOngoingCaptureSessionId } from "@/common/services/capture-query.ts";
 import { findHttpRequestByFetchRequestId } from "@/common/services/http-store.ts";
 import { isObject } from "@/common/utils/type-guard.ts";
-import { getOngoingCaptureSessionId } from "@/service-worker/capture-manager.ts";
 
 export function registerHttpInterceptionHandlers(
   onInterceptHttpRequest: (tabId: number, httpRequest: HttpRequest) => Promise<void>,

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -32,7 +32,7 @@ function init() {
 
   registerHttpInterceptionHandlers(
     async (tabId, httpRequest) => {
-      const sessionId = await processHttpRequest(tabId, httpRequest);
+      const sessionId = await processHttpRequest(httpRequest);
       if (sessionId instanceof Error) {
         console.warn("Failed to process HTTP request:", sessionId);
       } else if (sessionId !== undefined) {
@@ -43,7 +43,7 @@ function init() {
       }
     },
     async (tabId, httpResponse, pairedHttpRequest) => {
-      const sessionId = await processHttpResponse(tabId, httpResponse, pairedHttpRequest);
+      const sessionId = await processHttpResponse(httpResponse, pairedHttpRequest);
       if (sessionId instanceof Error) {
         console.warn("Failed to process HTTP response:", sessionId);
       } else if (sessionId !== undefined) {

--- a/src/service-worker/saml-tracer.test.ts
+++ b/src/service-worker/saml-tracer.test.ts
@@ -76,7 +76,7 @@ describe("processHttpRequest", () => {
     vi.mocked(saveHttpMessage).mockResolvedValue(undefined);
     vi.mocked(detectSamlStepFromHttpRequest).mockResolvedValue(undefined);
 
-    const result = await processHttpRequest(1, request);
+    const result = await processHttpRequest(request);
 
     expect(result).toBeUndefined();
     expect(saveHttpMessage).toHaveBeenCalledExactlyOnceWith(request);
@@ -88,7 +88,7 @@ describe("processHttpRequest", () => {
     vi.mocked(saveHttpMessage).mockResolvedValue(undefined);
     vi.mocked(detectSamlStepFromHttpRequest).mockResolvedValue(new Error("detection error"));
 
-    const result = await processHttpRequest(1, request);
+    const result = await processHttpRequest(request);
 
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("detection error");
@@ -105,13 +105,12 @@ describe("processHttpRequest", () => {
     });
     vi.mocked(recordSamlTrace).mockResolvedValue(undefined);
 
-    const result = await processHttpRequest(1, request);
+    const result = await processHttpRequest(request);
 
     expect(result).toBe("session-1");
     expect(saveHttpMessage).toHaveBeenCalledExactlyOnceWith(request);
     expect(recordSamlTrace).toHaveBeenCalledExactlyOnceWith(
       "capture-session-1",
-      1,
       { step: 3, correlationKey: "session-1" },
       request,
     );
@@ -121,7 +120,7 @@ describe("processHttpRequest", () => {
     const request = makeRequest();
     vi.mocked(saveHttpMessage).mockResolvedValue(new Error("store error"));
 
-    const result = await processHttpRequest(1, request);
+    const result = await processHttpRequest(request);
 
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("store error");
@@ -138,7 +137,7 @@ describe("processHttpRequest", () => {
     });
     vi.mocked(recordSamlTrace).mockResolvedValue(new Error("record error"));
 
-    const result = await processHttpRequest(1, request);
+    const result = await processHttpRequest(request);
 
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("record error");
@@ -156,14 +155,13 @@ describe("processHttpResponse", () => {
     vi.mocked(saveHttpMessage).mockResolvedValue(undefined);
     vi.mocked(recordSamlTrace).mockResolvedValue(undefined);
 
-    const result = await processHttpResponse(1, response, pairedRequest);
+    const result = await processHttpResponse(response, pairedRequest);
 
     expect(result).toBe("session-1");
     expect(detectSamlStepFromHttpResponse).toHaveBeenCalledWith(response, pairedRequest);
     expect(saveHttpMessage).toHaveBeenCalledExactlyOnceWith(response);
     expect(recordSamlTrace).toHaveBeenCalledExactlyOnceWith(
       "capture-session-1",
-      1,
       { step: 2, correlationKey: "session-1" },
       response,
       pairedRequest,
@@ -178,7 +176,7 @@ describe("processHttpResponse", () => {
     vi.mocked(detectSamlStepFromHttpRequest).mockResolvedValue(undefined);
     vi.mocked(deleteHttpMessages).mockResolvedValue(undefined);
 
-    const result = await processHttpResponse(1, response, pairedRequest);
+    const result = await processHttpResponse(response, pairedRequest);
 
     expect(result).toBeUndefined();
     expect(saveHttpMessage).not.toHaveBeenCalled();
@@ -196,7 +194,7 @@ describe("processHttpResponse", () => {
       correlationKey: "session-1",
     });
 
-    const result = await processHttpResponse(1, response, pairedRequest);
+    const result = await processHttpResponse(response, pairedRequest);
 
     expect(result).toBeUndefined();
     expect(deleteHttpMessages).not.toHaveBeenCalled();
@@ -209,7 +207,7 @@ describe("processHttpResponse", () => {
     vi.mocked(detectSamlStepFromHttpRequest).mockResolvedValue(undefined);
     vi.mocked(deleteHttpMessages).mockResolvedValue(new Error("delete error"));
 
-    const result = await processHttpResponse(1, response, pairedRequest);
+    const result = await processHttpResponse(response, pairedRequest);
 
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("delete error");
@@ -220,7 +218,7 @@ describe("processHttpResponse", () => {
     const response = makeResponse();
     vi.mocked(detectSamlStepFromHttpResponse).mockResolvedValue(new Error("detection error"));
 
-    const result = await processHttpResponse(1, response, pairedRequest);
+    const result = await processHttpResponse(response, pairedRequest);
 
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("detection error");
@@ -237,7 +235,7 @@ describe("processHttpResponse", () => {
     });
     vi.mocked(saveHttpMessage).mockResolvedValue(new Error("store error"));
 
-    const result = await processHttpResponse(1, response, pairedRequest);
+    const result = await processHttpResponse(response, pairedRequest);
 
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("store error");
@@ -254,7 +252,7 @@ describe("processHttpResponse", () => {
     vi.mocked(saveHttpMessage).mockResolvedValue(undefined);
     vi.mocked(recordSamlTrace).mockResolvedValue(new Error("record error"));
 
-    const result = await processHttpResponse(1, response, pairedRequest);
+    const result = await processHttpResponse(response, pairedRequest);
 
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toBe("record error");

--- a/src/service-worker/saml-tracer.ts
+++ b/src/service-worker/saml-tracer.ts
@@ -17,7 +17,6 @@ import {
 import { recordSamlTrace } from "@/common/services/saml-recorder.ts";
 
 export async function processHttpRequest(
-  tabId: number,
   httpRequest: HttpRequest,
 ): Promise<string | undefined | Error> {
   await debugHttpRequest(httpRequest);
@@ -34,12 +33,7 @@ export async function processHttpRequest(
     return undefined;
   }
 
-  const recordError = await recordSamlTrace(
-    httpRequest.captureSessionId,
-    tabId,
-    detection,
-    httpRequest,
-  );
+  const recordError = await recordSamlTrace(httpRequest.captureSessionId, detection, httpRequest);
   if (recordError) {
     return recordError;
   }
@@ -48,7 +42,6 @@ export async function processHttpRequest(
 }
 
 export async function processHttpResponse(
-  tabId: number,
   httpResponse: HttpResponse,
   pairedHttpRequest: HttpRequest,
 ): Promise<string | undefined | Error> {
@@ -79,7 +72,6 @@ export async function processHttpResponse(
 
   const recordError = await recordSamlTrace(
     httpResponse.captureSessionId,
-    tabId,
     detection,
     httpResponse,
     pairedHttpRequest,


### PR DESCRIPTION
- **Drop Session ID row from report page**
- **Look up flows by ID instead of correlation key**
- **Stop filtering flow summaries by tabs**
- **Remove tab-based reads of flows and traces**
- **Drop observed tab from SSO trace key**
